### PR TITLE
Update version number to 0.1.2 and fix CD run name

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,6 +1,6 @@
 name: PxVisualizer CD
 
-run-name: CD for ${{ github.event.head_commit.message }}
+run-name: CD for ${{ github.ref_name }}
 
 on:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {


### PR DESCRIPTION
Bump version number to hopefully get around the following issue with CD pipeline:
Cannot publish over previously published version "0.1.1-d.0".
Also uses ref_name for CD run name to fix empty names