### PR TITLE
Removes build step from CD and package.json cleanup

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -40,9 +40,6 @@ jobs:
     - name: Install dependencies
       run: npm ci --no-audit --quiet --prefer-offline
 
-    - name: Build
-      run: npm run build
-
     - name: Set current version
       run: |
         commitHash=$(git rev-parse HEAD)

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "storybook_legacy": "start-storybook -p 6006",
     "build-storybook": "set NODE_OPTIONS=--openssl-legacy-provider && build-storybook",
     "prepublishOnly": "npm run build",
-    "asd": "npm run build && clean-publish --without-publish && npm --prefix package/ pack",
-    "publish": "clean-publish",
     "version-helper": "node .github/scripts/version-helper.js"
   },
   "repository": {


### PR DESCRIPTION
Build is built automatically during the publish process so skipping build step will save some time
Also removes "asd" and "publish" scripts from package.json. "publish" may have caused issues in our CD pipeline trying to publish multiple times with the same command.