### PR TITLE
Removes pr's against main and test from CI triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - dev
-      - test
-      - main
   push:
     branches:
       - dev


### PR DESCRIPTION
This should fix the issue where CI and CD are unnecessarily ran when there's a PR against test or main