### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {


### PR DESCRIPTION
Version number was not updated during latest merges to develop. This in preparation for new releases.