### PR TITLE
Dependabot version incrementation workflow and sonarscan exlcusion

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,4 +44,4 @@ jobs:
 
     - name: Validate version bump
       run: npm run version-helper validate
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/SonarScan.yml
+++ b/.github/workflows/SonarScan.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
  sonar:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dependabot_version_increment.yml
+++ b/.github/workflows/dependabot_version_increment.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
  dependabot_version_increment:
-    if: ${{ github.actor = 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dependabot_version_increment.yml
+++ b/.github/workflows/dependabot_version_increment.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
  dependabot_version_increment:
-    #if: ${{ github.actor = 'dependabot[bot]' }} commented this out for testing
+    if: ${{ github.actor = 'dependabot[bot]' }} commented this out for testing
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dependabot_version_increment.yml
+++ b/.github/workflows/dependabot_version_increment.yml
@@ -1,0 +1,50 @@
+name: dependabot Version Increment
+
+run-name: ${{ format('dependabot Version Increment for PR {0}', github.event.pull_request.number) }}
+
+on:
+  pull_request:
+    branches:
+      - 'dev'
+
+jobs:
+ dependabot_version_increment:
+    #if: ${{ github.actor = 'dependabot[bot]' }} commented this out for testing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21.x'
+
+      - name: Get current version number from main branch
+        run: |
+          git fetch origin main
+          git checkout origin/main -- package.json
+          echo "CURRENT_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
+
+      - name: Get version number from PR branch
+        run: |
+          PR_VERSION=$(jq -r '.version' package.json)
+          echo "PR_VERSION=$PR_VERSION" >> $GITHUB_ENV
+
+      - name: Compare and increment version number
+        run: |
+          if [ "$CURRENT_VERSION" = "$PR_VERSION" ]; then
+            npm version patch --no-git-tag-version
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add package.json
+            git commit -m "Version bump from $PR_VERSION to $(jq -r '.version' package.json)"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          fi

--- a/.github/workflows/dependabot_version_increment.yml
+++ b/.github/workflows/dependabot_version_increment.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
  dependabot_version_increment:
-    if: ${{ github.actor = 'dependabot[bot]' }} commented this out for testing
+    if: ${{ github.actor = 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {


### PR DESCRIPTION
Excludes sonarscan from using sonar scan job and version checker script.
New job only for dependabot pr's that checks prod version number and increments the version patch number in its pr if required.