### PR TITLE
Auto rotation for ordinal x axis labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/chartOptions/Utility/ordinalIntervals.test.ts
+++ b/src/core/chartOptions/Utility/ordinalIntervals.test.ts
@@ -9,8 +9,8 @@ describe('ordinalOptions tests', () => {
         units: [],
         sources: [],
         columnNameGroups: [
-            [{ 'fi': 'test_1_fi', 'en': 'test_1_en', 'sv': 'test_1_sv' }],
-            [{ 'fi': 'test_2_fi', 'en': 'test_2_en', 'sv': 'test_2_sv' }]
+            [{ 'fi': '1', 'en': '1', 'sv': '1' }],
+            [{ 'fi': '2', 'en': '2', 'sv': '2' }]
         ],
         series: [],
         colVarNames: [],
@@ -37,8 +37,8 @@ describe('ordinalOptions tests', () => {
         const result = getOrdinalOptions(irregularTimeView, 'fi');
         expect(result.categories).toEqual(
             [
-                "test_1_fi",
-                "test_2_fi",
+                "1",
+                "2",
             ]);
         expect(result.type).toEqual('category');
         expect(result.ordinal).toEqual(true);

--- a/src/core/chartOptions/Utility/ordinalIntervals.ts
+++ b/src/core/chartOptions/Utility/ordinalIntervals.ts
@@ -13,6 +13,6 @@ export const getOrdinalOptions: (view: View, locale: string) => XAxisOptions = (
             Math.max(...view.columnNameGroups.map(cng =>
                 cng.reduce((acc: number, mls: TMultiLanguageString) => {
                     return (acc > 0 ? 1 : 0) + acc + mls[locale].length
-                }, 0)))),
+                }, 0))))
     };
 };

--- a/src/core/chartOptions/Utility/ordinalIntervals.ts
+++ b/src/core/chartOptions/Utility/ordinalIntervals.ts
@@ -14,6 +14,9 @@ export const getOrdinalOptions: (view: View, locale: string) => XAxisOptions = (
             Math.max(...view.columnNameGroups.map(cng =>
                 cng.reduce((acc: number, mls: TMultiLanguageString) => {
                     return (acc > 0 ? 1 : 0) +  acc + mls[locale].length
-                }, 0))))
+                }, 0)))),
+        labels: {
+            autoRotation: [-45]
+        }
     };
 };

--- a/src/core/chartOptions/Utility/ordinalIntervals.ts
+++ b/src/core/chartOptions/Utility/ordinalIntervals.ts
@@ -4,7 +4,6 @@ import { getOrdinalAxisTickPositionerFunction } from "./tickPositioners";
 import { TMultiLanguageString } from "../../types/queryVisualizationResponse";
 
 export const getOrdinalOptions: (view: View, locale: string) => XAxisOptions = (view, locale) => {
-    
     return {
         type: 'category',
         categories: view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', ')),
@@ -13,10 +12,7 @@ export const getOrdinalOptions: (view: View, locale: string) => XAxisOptions = (
             Math.max(...view.series.map(s => s.series.length)),
             Math.max(...view.columnNameGroups.map(cng =>
                 cng.reduce((acc: number, mls: TMultiLanguageString) => {
-                    return (acc > 0 ? 1 : 0) +  acc + mls[locale].length
+                    return (acc > 0 ? 1 : 0) + acc + mls[locale].length
                 }, 0)))),
-        labels: {
-            autoRotation: [-45]
-        }
     };
 };

--- a/src/core/chartOptions/Utility/timeIntervals.test.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.test.ts
@@ -99,7 +99,8 @@ describe('getXAxisOptions tests', () => {
             type: 'category',
             labels: {
                 autoRotation: [-45]
-            }
+            },
+            ordinal: false
         });
     });
 
@@ -122,7 +123,8 @@ describe('getXAxisOptions tests', () => {
             type: 'category',
             labels: {
                 autoRotation: [-45]
-            }
+            },
+            ordinal: true
         });
     });
 

--- a/src/core/chartOptions/Utility/timeIntervals.test.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.test.ts
@@ -221,6 +221,4 @@ describe('getXAxisOptions tests', () => {
             type: 'datetime'
         });
     });
-
-    //TODO: Test with numeric and non-numeric ordinal column name groups
 });

--- a/src/core/chartOptions/Utility/timeIntervals.test.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.test.ts
@@ -103,10 +103,10 @@ describe('getXAxisOptions tests', () => {
         });
     });
 
-    it('Should return correct options when series type is ordinal', () => {
+    it('Should return correct options when series type is ordinal with non-numeric values', () => {
         const irregularOrdinalView = {
             ...mockView,
-            seriesType: ESeriesType.Nominal,
+            seriesType: ESeriesType.Ordinal,
             visualizationSettings: {
                 ...mockView.visualizationSettings,
                 timeVariableIntervals: ETimeVariableInterval.Irregular
@@ -124,6 +124,25 @@ describe('getXAxisOptions tests', () => {
                 autoRotation: [-45]
             }
         });
+    });
+
+    it('Should return correct options when series type is ordinal with numeric values', () => {
+        const irregularOrdinalView = {
+            ...mockView,
+            seriesType: ESeriesType.Ordinal,
+            visualizationSettings: {
+                ...mockView.visualizationSettings
+            },
+            columnNameGroups: [
+                [{ 'fi': '1', 'en': '1', 'sv': '1' }],
+                [{ 'fi': '2', 'en': '2', 'sv': '2' }]
+            ]
+        };
+
+        const result = getXAxisOptions(irregularOrdinalView, 'fi');
+        expect(result.ordinal).toEqual(true);
+        expect(result.type).toEqual('category');
+        expect(result.categories).toEqual(["1", "2"]);
     });
 
     it('Should return correct options when interval is week', () => {
@@ -202,4 +221,6 @@ describe('getXAxisOptions tests', () => {
             type: 'datetime'
         });
     });
+
+    //TODO: Test with numeric and non-numeric ordinal column name groups
 });

--- a/src/core/chartOptions/Utility/timeIntervals.test.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.test.ts
@@ -1,4 +1,4 @@
-import { ETimeVariableInterval } from "../../types";
+﻿import { ETimeVariableInterval } from "../../types";
 import { EVisualizationType } from "../../types/queryVisualizationResponse";
 import { ESeriesType, View } from "../../types/view";
 import { getTimeSeriesOptions, getXAxisOptions } from "./timeIntervals";
@@ -128,6 +128,36 @@ describe('getXAxisOptions tests', () => {
         });
     });
 
+    it('Should return correct options when series type is ordinal with cyrillic value names', () => {
+        const irregularOrdinalView = {
+            ...mockView,
+            columnNameGroups: [
+                [{ 'fi': 'Фообар-1', 'en': 'test_1_en', 'sv': 'test_1_sv' }],
+                [{ 'fi': 'Фообар-2', 'en': 'test_2_en', 'sv': 'test_2_sv' }]
+            ],
+            seriesType: ESeriesType.Ordinal,
+            visualizationSettings: {
+                ...mockView.visualizationSettings,
+                timeVariableIntervals: ETimeVariableInterval.Irregular
+            }
+        };
+
+        const result = getXAxisOptions(irregularOrdinalView, 'fi');
+        expect(result).toEqual({
+            categories: [
+                // foobar in cyrillic
+                'Фообар-1',
+                'Фообар-2'
+            ],
+            type: 'category',
+            labels: {
+                autoRotation: [-45]
+            },
+            ordinal: true
+        });
+    });
+
+
     it('Should return correct options when series type is ordinal with numeric values', () => {
         const irregularOrdinalView = {
             ...mockView,
@@ -136,15 +166,19 @@ describe('getXAxisOptions tests', () => {
                 ...mockView.visualizationSettings
             },
             columnNameGroups: [
-                [{ 'fi': '1', 'en': '1', 'sv': '1' }],
-                [{ 'fi': '2', 'en': '2', 'sv': '2' }]
+                [{ 'fi': '1 234 567,8', 'en': '1,234,567.8', 'sv': '1' }],
+                [{ 'fi': '-2 345 678,9', 'en': '-2,345,678.9', 'sv': '2' }]
             ]
         };
 
-        const result = getXAxisOptions(irregularOrdinalView, 'fi');
-        expect(result.ordinal).toEqual(true);
-        expect(result.type).toEqual('category');
-        expect(result.categories).toEqual(["1", "2"]);
+        const resultFi = getXAxisOptions(irregularOrdinalView, 'fi');
+        const resultEn = getXAxisOptions(irregularOrdinalView, 'en');
+        expect(resultFi.ordinal).toEqual(true);
+        expect(resultFi.type).toEqual('category');
+        expect(resultFi.categories).toEqual(['1 234 567,8', '-2 345 678,9']);
+        expect(resultEn.ordinal).toEqual(true);
+        expect(resultEn.type).toEqual('category');
+        expect(resultEn.categories).toEqual(['1,234,567.8', '-2,345,678.9']);
     });
 
     it('Should return correct options when interval is week', () => {

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -61,6 +61,7 @@ export function getXAxisOptions(view: View, locale: string): XAxisOptions {
         }
         else { // Nominal or non-numeric ordinal
             return {
+                ordinal: view.seriesType == ESeriesType.Ordinal,
                 type: 'category',
                 categories: labels,
                 labels: {

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -52,17 +52,22 @@ export function getXAxisOptions(view: View, locale: string): XAxisOptions {
                     categories: view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', '))
                 };
         }
-    } else if (view.seriesType === ESeriesType.Ordinal) {
-        return getOrdinalOptions(view, locale);
     }
-    else { // Nominal
-        return {
-            type: 'category',
-            categories: view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', ')),
-            labels: {
-                autoRotation: [-45]
-            }
-        };
+    else {
+        const labels: string[] = view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', '));
+        const numeric: boolean = !labels.some(l => /[a-zA-Z]/.test(l));
+        if (view.seriesType === ESeriesType.Ordinal && numeric) {
+            return getOrdinalOptions(view, locale);
+        }
+        else { // Nominal or non-numeric ordinal
+            return {
+                type: 'category',
+                categories: labels,
+                labels: {
+                    autoRotation: [-45]
+                }
+            };
+        }
     }
 }
 

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -56,10 +56,7 @@ export function getXAxisOptions(view: View, locale: string): XAxisOptions {
     }
     else {
         const labels: string[] = view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', '));
-        const decimalDelimeter = Translations.decimalPoint[locale];
-        const thousandsSeparator = Translations.thousandsSep[locale];
-        const allowedCharacters = new RegExp(`^[0-9\\-\\${decimalDelimeter}\\${thousandsSeparator}]+$`);
-        const numeric: boolean = labels.every(l => allowedCharacters.test(l));
+        const numeric: boolean = labels.every(l => !isNaN(parseFloat(l)));
         if (view.seriesType === ESeriesType.Ordinal && numeric) {
             return getOrdinalOptions(view, locale);
         }

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -59,7 +59,7 @@ export function getXAxisOptions(view: View, locale: string): XAxisOptions {
         const decimalDelimeter = Translations.decimalPoint[locale];
         const thousandsSeparator = Translations.thousandsSep[locale];
         const allowedCharacters = new RegExp(`^[0-9\\-\\${decimalDelimeter}\\${thousandsSeparator}]+$`);
-        const numeric: boolean = labels.every(l => !allowedCharacters.test(l));
+        const numeric: boolean = labels.every(l => allowedCharacters.test(l));
         if (view.seriesType === ESeriesType.Ordinal && numeric) {
             return getOrdinalOptions(view, locale);
         }

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -59,7 +59,7 @@ export function getXAxisOptions(view: View, locale: string): XAxisOptions {
         const decimalDelimeter = Translations.decimalPoint[locale];
         const thousandsSeparator = Translations.thousandsSep[locale];
         const allowedCharacters = new RegExp(`^[0-9\\-\\${decimalDelimeter}\\${thousandsSeparator}]+$`);
-        const numeric: boolean = !labels.some(l => !allowedCharacters.test(l));
+        const numeric: boolean = labels.every(l => !allowedCharacters.test(l));
         if (view.seriesType === ESeriesType.Ordinal && numeric) {
             return getOrdinalOptions(view, locale);
         }

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -3,7 +3,6 @@ import Highcharts, { PlotSeriesOptions, XAxisOptions } from "highcharts";
 import { ESeriesType, View } from "../../types/view";
 import { getBiannualSeriesTickPositionerFunction, getQuarterlySeriesTickPositionerFunction } from "./tickPositioners";
 import { getOrdinalOptions } from "./ordinalIntervals";
-import Translations from "../../conversion/translations";
 
 export function getTimeSeriesOptions(interval: ETimeVariableInterval, startingPoint: string | null | undefined): PlotSeriesOptions | undefined {
     if (!startingPoint) return undefined;

--- a/src/core/chartOptions/Utility/timeIntervals.ts
+++ b/src/core/chartOptions/Utility/timeIntervals.ts
@@ -3,6 +3,7 @@ import Highcharts, { PlotSeriesOptions, XAxisOptions } from "highcharts";
 import { ESeriesType, View } from "../../types/view";
 import { getBiannualSeriesTickPositionerFunction, getQuarterlySeriesTickPositionerFunction } from "./tickPositioners";
 import { getOrdinalOptions } from "./ordinalIntervals";
+import Translations from "../../conversion/translations";
 
 export function getTimeSeriesOptions(interval: ETimeVariableInterval, startingPoint: string | null | undefined): PlotSeriesOptions | undefined {
     if (!startingPoint) return undefined;
@@ -55,7 +56,10 @@ export function getXAxisOptions(view: View, locale: string): XAxisOptions {
     }
     else {
         const labels: string[] = view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', '));
-        const numeric: boolean = !labels.some(l => /[a-zA-Z]/.test(l));
+        const decimalDelimeter = Translations.decimalPoint[locale];
+        const thousandsSeparator = Translations.thousandsSep[locale];
+        const allowedCharacters = new RegExp(`^[0-9\\-\\${decimalDelimeter}\\${thousandsSeparator}]+$`);
+        const numeric: boolean = !labels.some(l => !allowedCharacters.test(l));
         if (view.seriesType === ESeriesType.Ordinal && numeric) {
             return getOrdinalOptions(view, locale);
         }

--- a/src/stories/chart.stories.tsx
+++ b/src/stories/chart.stories.tsx
@@ -63,6 +63,7 @@ import {
   LINE_CHART_WITH_MULTISELECTABLE_VARIABLE,
   LINE_CHART_WITH_NEGATIVE_VALUES,
   LINE_CHART_WITH_NON_TIME_ORDINAL,
+  LINE_CHART_WITH_NON_NUMERIC_ORDINAL,
   LINE_CHART_WITH_ORDINAL_VAR,
   LINE_CHART_WITH_QUARTER_SERIES,
   LINE_CHART_WITH_YEAR_SERIES,
@@ -121,6 +122,9 @@ LineChartWithNegativeValues.args = LINE_CHART_WITH_NEGATIVE_VALUES;
 
 export const LineChartWithNonTimeOrdinal = Template.bind({});
 LineChartWithNonTimeOrdinal.args = LINE_CHART_WITH_NON_TIME_ORDINAL;
+
+export const LineChartWithNonNumericOrdinal = Template.bind({});
+LineChartWithNonNumericOrdinal.args = LINE_CHART_WITH_NON_NUMERIC_ORDINAL;
 
 export const LineChartWithOrdinalVariable = Template.bind({});
 LineChartWithOrdinalVariable.args = LINE_CHART_WITH_ORDINAL_VAR;

--- a/src/stories/chart.stories.tsx
+++ b/src/stories/chart.stories.tsx
@@ -7,6 +7,7 @@ import {
   VERTICAL_BAR_CHART_WITH_PRELIMINARY_DATA,
   VERTICAL_BAR_CHART_WITH_CUSTOM_MENU_ITEMS,
   VERTICAL_BAR_CHART_WITH_NEGATIVE_VALUES,
+  VERTICAL_BAR_CHART_WITH_LONG_ORDINAL_LABELS,
   VERTICAL_BAR_CHART_WITH_SELECTABLES,
 } from "./fixtures/verticalBarChart";
 import {
@@ -135,6 +136,9 @@ verticalBarChartWithPreliminaryData.args = VERTICAL_BAR_CHART_WITH_PRELIMINARY_D
 
 export const verticalBarChartWithNegativeValues = Template.bind({});
 verticalBarChartWithNegativeValues.args = VERTICAL_BAR_CHART_WITH_NEGATIVE_VALUES;
+
+export const verticalBarChartWithLongOrdinalLabels = Template.bind({});
+verticalBarChartWithLongOrdinalLabels.args = VERTICAL_BAR_CHART_WITH_LONG_ORDINAL_LABELS;
 
 export const HorizontalBarChartAscending = Template.bind({});
 HorizontalBarChartAscending.args = HORIZONTAL_BAR_CHART_ASCENDING;

--- a/src/stories/fixtures/lineChart.ts
+++ b/src/stories/fixtures/lineChart.ts
@@ -5946,6 +5946,250 @@ export const LINE_CHART_WITH_NON_TIME_ORDINAL: { pxGraphData: IQueryVisualizatio
     selectedVariableCodes: undefined
 }
 
+export const LINE_CHART_WITH_NON_NUMERIC_ORDINAL: { pxGraphData: IQueryVisualizationResponse, selectedVariableCodes: TVariableSelections | undefined } = {
+    pxGraphData: {
+        tableReference: { name: "table.px", hierarchy: ["foo", "bar"] },
+        data: [
+            178936.0,
+            162358.0,
+            174856.0,
+            183465.0,
+            175134.0,
+            169845.0,
+            165833.0,
+            103742.0,
+            65005.0,
+            49799.0
+        ],
+        missingDataInfo: {},
+        dataNotes: {},
+        metaData: [
+            {
+                "code": "Vuosi",
+                "name": {
+                    "fi": "Vuosi",
+                    "sv": "År",
+                    "en": "Year"
+                },
+                "note": null,
+                "type": EVariableType.Time,
+                "values": [
+                    {
+                        "code": "2020",
+                        "name": {
+                            "fi": "2020",
+                            "sv": "2020",
+                            "en": "2020"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    }
+                ]
+            },
+            {
+                "code": "Sukupuoli",
+                "name": {
+                    "fi": "Sukupuoli",
+                    "sv": "Kön",
+                    "en": "Sex"
+                },
+                "note": null,
+                "type": EVariableType.OtherClassificatory,
+                "values": [
+                    {
+                        "code": "1",
+                        "name": {
+                            "fi": "Miehet",
+                            "sv": "Män",
+                            "en": "Males"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    }
+                ]
+            },
+            {
+                "code": "Tiedot",
+                "name": {
+                    "fi": "Tiedot",
+                    "sv": "Uppgifter",
+                    "en": "Information"
+                },
+                "note": null,
+                "type": EVariableType.Content,
+                "values": [
+                    {
+                        "code": "vaesto",
+                        "name": {
+                            "fi": "Väestö 31.12.",
+                            "sv": "Befolkning 31.12.",
+                            "en": "Population 31 Dec"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": {
+                            "unit": {
+                                "fi": "Lukumäärä",
+                                "sv": "Antal",
+                                "en": "Number"
+                            },
+                            "source": {
+                                "fi": "PxVisualizer-fi",
+                                "sv": "PxVisualizer-sv",
+                                "en": "PxVisualizer-en"
+                            },
+                            "numberOfDecimals": 0,
+                            "lastUpdated": "2023-03-31T05:00:00Z"
+                        }
+                    }
+                ]
+            },
+            {
+                "code": "Ikä",
+                "name": {
+                    "fi": "Ikä",
+                    "sv": "Ålder",
+                    "en": "Age"
+                },
+                "note": null,
+                "type": EVariableType.Ordinal,
+                "values": [
+                    {
+                        "code": "40-44",
+                        "name": {
+                            "fi": "foo",
+                            "sv": "foo.en",
+                            "en": "foo.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "45-49",
+                        "name": {
+                            "fi": "bar",
+                            "sv": "bar.en",
+                            "en": "bar.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "50-54",
+                        "name": {
+                            "fi": "baz",
+                            "sv": "baz.en",
+                            "en": "baz.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "55-59",
+                        "name": {
+                            "fi": "qux",
+                            "sv": "qux.en",
+                            "en": "qux.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "60-64",
+                        "name": {
+                            "fi": "quux",
+                            "sv": "quux.en",
+                            "en": "quux.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "65-69",
+                        "name": {
+                            "fi": "corge",
+                            "sv": "corge.en",
+                            "en": "corge.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "70-74",
+                        "name": {
+                            "fi": "grault",
+                            "sv": "grault.en",
+                            "en": "grault.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "75-79",
+                        "name": {
+                            "fi": "garply",
+                            "sv": "garply.en",
+                            "en": "garply.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "80-84",
+                        "name": {
+                            "fi": "waldo",
+                            "sv": "waldo.en",
+                            "en": "waldo.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "85-",
+                        "name": {
+                            "fi": "fred",
+                            "sv": "fred.en",
+                            "en": "fred.sv"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    }
+                ]
+            }
+        ],
+        "selectableVariableCodes": [],
+        "rowVariableCodes": [],
+        "columnVariableCodes": [
+            "Ikä"
+        ],
+        "header": {
+            "fi": "Väestö 31.12., Miehet 2020 muuttujana Ikä",
+            "sv": "Befolkning 31.12., Män 2020 efter Ålder",
+            "en": "Population 31 Dec, Males 2020 by Age"
+        },
+        "visualizationSettings": {
+            "visualizationType": EVisualizationType.LineChart,
+            "timeVariableIntervals": ETimeVariableInterval.Year,
+            "timeSeriesStartingPoint": "2020-01-01T00:00:00",
+            "cutValueAxis": false,
+            "showLastLabel": false
+        }
+    },
+    selectedVariableCodes: undefined
+}
+
 export const LINE_CHART_WITH_HALF_YEAR_SERIES: { pxGraphData: IQueryVisualizationResponse, selectedVariableCodes: TVariableSelections | undefined } = {
     pxGraphData: {
         tableReference: { name: "table.px", hierarchy: ["foo", "bar"] },

--- a/src/stories/fixtures/verticalBarChart.ts
+++ b/src/stories/fixtures/verticalBarChart.ts
@@ -677,6 +677,160 @@ export const VERTICAL_BAR_CHART_WITH_PRELIMINARY_DATA: {
     selectedVariableCodes: undefined
 }
 
+export const VERTICAL_BAR_CHART_WITH_LONG_ORDINAL_LABELS: { pxGraphData: IQueryVisualizationResponse, selectedVariableCodes: TVariableSelections | undefined } = {
+    pxGraphData: {
+        tableReference: { name: "table.px", hierarchy: ["foo", "bar"] },
+        "data": [28.1, 50.2, 66.7, 73.9],
+        "dataNotes": {},
+        "missingDataInfo": {},
+        "metaData": [
+            {
+                "code": "Vuosi",
+                "name": {
+                    "fi": "Vuosi", "sv": "År", "en": "Year"
+                },
+                "note": null,
+                "type": EVariableType.Time,
+                "values": [
+                    {
+                        "code": "2018", "name": {
+                            "fi": "2018", "sv": "2018", "en": "2018"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    }
+                ]
+            },
+            {
+                "code": "Sukupuoli",
+                "name": {
+                    "fi": "Sukupuoli", "sv": "Kön", "en": "Gender"
+                },
+                "note": null,
+                "type": EVariableType.OtherClassificatory,
+                "values": [
+                    {
+                        "code": "SSS", "name": {
+                            "fi": "Yhteensä", "sv": "Totalt", "en": "Total"
+                        },
+                        "note": null,
+                        "isSum": true,
+                        "contentComponent": null
+                    }
+                ]
+            },
+            {
+                "code": "Koulutusaste",
+                "name": {
+                    "fi": "Koulutusaste", "sv": "Utbildningsnivå", "en": "Level of education"
+                },
+                "note": null,
+                "type": EVariableType.OtherClassificatory,
+                "values": [
+                    {
+                        "code": "SSS", "name": {
+                            "fi": "Yhteensä", "sv": "Totalt", "en": "Total"
+                        },
+                        "note": null,
+                        "isSum": true,
+                        "contentComponent": null
+                    }
+                ]
+            },
+            {
+                "code": "Tiedot", "name": {
+                    "fi": "Tiedot",
+                    "sv": "Uppgifter",
+                    "en": "Information"
+                },
+                "note": null,
+                "type": EVariableType.Content,
+                "values": [
+                    {
+                        "code": "opisk_pro",
+                        "name": {
+                            "fi": "Tilastovuonna valmistuneet ylioppilaat, %", "sv": "Studenter som utexaminerats under statistikåret, %", "en": "Passers of the matriculation examination in the statistical reference year, %"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": {
+                            "unit": {
+                                "fi": "prosentti", "sv": "procent", "en": "per cent"
+                            },
+                            "source": {
+                                "fi": "Tilastokeskus, koulutukseen hakeutuminen", "sv": "Statistikcentralen, sökande till utbildning", "en": "Statistics Finland, entrance to education"
+                            },
+                            "numberOfDecimals": 1,
+                            "lastUpdated": "2022-12-08T06:00:00Z"
+                        }
+                    }
+                ]
+            },
+            {
+                "code": "Opiskelutilanne",
+                "name": {
+                    "fi": "Opiskelutilanne", "sv": "Mellanår", "en": "Studying situation"
+                },
+                "note": null,
+                "type": EVariableType.Ordinal,
+                "values": [
+                    {
+                        "code": "0",
+                        "name": {
+                            "fi": "Opiskelemassa valmistumisvuonna",
+                            "sv": "Studerar omedelbart under examensåret",
+                            "en": "Studying immediately in the year of graduation"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "1",
+                        "name": {
+                            "fi": "Opiskelemassa 1 vuosi valmistumisen jälkeen", "sv": "Studerar 1 år efter utexaminering", "en": "Studying one year after graduation"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "2",
+                        "name": {
+                            "fi": "Opiskelemassa 2 vuotta valmistumisen jälkeen", "sv": "Studerar 2 år efter utexaminering", "en": "Studying two years after graduation"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    },
+                    {
+                        "code": "3",
+                        "name": {
+                            "fi": "Opiskelemassa 3 vuotta valmistumisen jälkeen", "sv": "Studerar 3 år efter utexaminering", "en": "Studying three years after graduation"
+                        },
+                        "note": null,
+                        "isSum": false,
+                        "contentComponent": null
+                    }
+                ]
+            }],
+        "selectableVariableCodes": [],
+        "rowVariableCodes": [],
+        "columnVariableCodes": ["Opiskelutilanne"],
+        "header": { "fi": "Vuonna 2018 ylioppilaaksi valmistuneiden jatkokoulutukseen pääsy vuosina 2018–2021, %", "sv": "Studenter som utexaminerats under statistikåret, %, 2018", "en": "Passers of the matriculation examination in the statistical reference year, %, 2018" },
+        "visualizationSettings": {
+            "visualizationType": EVisualizationType.VerticalBarChart,
+            "timeVariableIntervals": ETimeVariableInterval.Year,
+            "timeSeriesStartingPoint": "2018-01-01T00:00:00Z",
+            "cutValueAxis": false,
+            "showLastLabel": true,
+            "showDataPoints": false
+        }
+    },
+    selectedVariableCodes: undefined
+}
+
 export const VERTICAL_BAR_CHART_WITH_NEGATIVE_VALUES: {
     pxGraphData: IQueryVisualizationResponse,
     selectedVariableCodes: TVariableSelections | undefined,


### PR DESCRIPTION
Auto rotation of 45 degrees is applied to non-numeric ordinal variable x axis labels if they do not fit the screen otherwise, same as with nominal variables.

Added a new storybook fixture and tests to cover this case