### PR TITLE
Dependabot version increment fix

### DIFF
--- a/.github/workflows/dependabot_version_increment.yml
+++ b/.github/workflows/dependabot_version_increment.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
  dependabot_version_increment:
-   # if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Component library for visualizing PxGraf data THIS IS A TEST CHANGE!",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.0.9",
-  "description": "Component library for visualizing PxGraf data THIS IS A TEST CHANGE!",
+  "version": "1.0.8",
+  "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {
     "reportPath": "reports",


### PR DESCRIPTION
Fixes the issue where dependency updates to package.json are overran by the version increment check by using show instead of checking out main package.json for the version check.

Tested in this branch.