### PR TITLE
Accessibility improvements for tables and burger menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/highcharts/drawChart.ts
+++ b/src/core/highcharts/drawChart.ts
@@ -4,7 +4,6 @@ import { IQueryVisualizationResponse } from "../types";
 import { defaultTheme } from "./themes";
 import highchartsAccessibility from "highcharts/modules/accessibility.js";
 import highchartsExporting from 'highcharts/modules/exporting.js';
-import highchartsExportData from 'highcharts/modules/export-data.js';
 import highchartsOfflineExporting from 'highcharts/modules/offline-exporting.js';
 import { TVariableSelections } from "../types/variableSelections";
 import { extractSelectableVariableValues } from "../conversion/helpers";
@@ -22,7 +21,6 @@ export const drawChart = (
     if (typeof Highcharts === 'object') {
         highchartsAccessibility(Highcharts);
         highchartsExporting(Highcharts);
-        highchartsExportData(Highcharts);
         highchartsOfflineExporting(Highcharts);
     }
     Highcharts.setOptions(defaultTheme(validLocale));

--- a/src/core/styles/chart.css
+++ b/src/core/styles/chart.css
@@ -51,3 +51,11 @@
     margin-top: 6px;
     width: 90%;
 }
+
+.tableChart .caption {
+    margin-top: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-bottom: 0rem;
+    width: 90%;
+}

--- a/src/core/styles/chart.css
+++ b/src/core/styles/chart.css
@@ -51,11 +51,3 @@
     margin-top: 6px;
     width: 90%;
 }
-
-.tableChart .caption {
-    margin-top: 0;
-    font-size: 1.25rem;
-    font-weight: 500;
-    margin-bottom: 0rem;
-    width: 90%;
-}

--- a/src/core/tables/__snapshots__/htmlTable.test.ts.snap
+++ b/src/core/tables/__snapshots__/htmlTable.test.ts.snap
@@ -9,11 +9,7 @@ exports[`Html table render tests should match snapshot: Table with column variab
   [36m>[39m
     [36m<caption[39m
       [33mclass[39m=[32m"tableChart-caption"[39m
-    [36m>[39m
-      [0mAdoptiot 1987-1989 muuttujina Syntymävaltio, Ikä[0m
-      [36m<br />[39m
-      [0m[0m
-    [36m</caption>[39m
+    [36m/>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<th[39m
@@ -447,11 +443,7 @@ exports[`Html table render tests should match snapshot: Table with only one cell
   [36m>[39m
     [36m<caption[39m
       [33mclass[39m=[32m"tableChart-caption"[39m
-    [36m>[39m
-      [0mLukumäärä, Vantaa, Yksiöt, Vapaarahoitteinen 2022Q4[0m
-      [36m<br />[39m
-      [0m[0m
-    [36m</caption>[39m
+    [36m/>[39m
     [36m<tbody>[39m
       [36m<tr>[39m
         [36m<td>[39m
@@ -478,11 +470,7 @@ exports[`Html table render tests should match snapshot: Table with row and colum
   [36m>[39m
     [36m<caption[39m
       [33mclass[39m=[32m"tableChart-caption"[39m
-    [36m>[39m
-      [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
-      [36m<br />[39m
-      [0m[0m
-    [36m</caption>[39m
+    [36m/>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -1120,11 +1108,7 @@ exports[`Html table render tests should match snapshot: Table with row and colum
   [36m>[39m
     [36m<caption[39m
       [33mclass[39m=[32m"tableChart-caption"[39m
-    [36m>[39m
-      [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
-      [36m<br />[39m
-      [0m[0m
-    [36m</caption>[39m
+    [36m/>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -2394,11 +2378,7 @@ exports[`Html table render tests should match snapshot: Table with row and colum
   [36m>[39m
     [36m<caption[39m
       [33mclass[39m=[32m"tableChart-caption"[39m
-    [36m>[39m
-      [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
-      [36m<br />[39m
-      [0m[0m
-    [36m</caption>[39m
+    [36m/>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -3030,11 +3010,7 @@ exports[`Html table render tests should match snapshot: Table with row variables
   [36m>[39m
     [36m<caption[39m
       [33mclass[39m=[32m"tableChart-caption"[39m
-    [36m>[39m
-      [0mLukumäärä 2022Q1-2022Q4 muuttujina Alue, Huoneluku, Rahoitusmuoto[0m
-      [36m<br />[39m
-      [0m[0m
-    [36m</caption>[39m
+    [36m/>[39m
     [36m<tbody>[39m
       [36m<tr>[39m
         [36m<th[39m

--- a/src/core/tables/__snapshots__/htmlTable.test.ts.snap
+++ b/src/core/tables/__snapshots__/htmlTable.test.ts.snap
@@ -4,12 +4,16 @@ exports[`Html table render tests should match snapshot: Table with column variab
 "[36m<div[39m
   [33mid[39m=[32m"test-49857934857938475938475"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mAdoptiot 1987-1989 muuttujina Syntymävaltio, Ikä[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mAdoptiot 1987-1989 muuttujina Syntymävaltio, Ikä[0m
+      [36m<br />[39m
+      [0m[0m
+    [36m</caption>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<th[39m
@@ -280,17 +284,16 @@ exports[`Html table render tests should match snapshot: Table with missing data 
 "[36m<div[39m
   [33mid[39m=[32m"test-84957394875983745"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mNeliöhinta (EUR/m2), Helsinki 2020Q1-2023Q2* muuttujina Talotyyppi, Huoneluku[0m
-  [36m</span>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"subtitle"[39m
-  [36m>[39m
-    [0mRivitalot | Kaksiot[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mNeliöhinta (EUR/m2), Helsinki 2020Q1-2023Q2* muuttujina Talotyyppi, Huoneluku[0m
+      [36m<br />[39m
+      [0mRivitalot | Kaksiot[0m
+    [36m</caption>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<th[39m
@@ -439,12 +442,16 @@ exports[`Html table render tests should match snapshot: Table with only one cell
 "[36m<div[39m
   [33mid[39m=[32m"test-6895638450983059889"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mLukumäärä, Vantaa, Yksiöt, Vapaarahoitteinen 2022Q4[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mLukumäärä, Vantaa, Yksiöt, Vapaarahoitteinen 2022Q4[0m
+      [36m<br />[39m
+      [0m[0m
+    [36m</caption>[39m
     [36m<tbody>[39m
       [36m<tr>[39m
         [36m<td>[39m
@@ -466,12 +473,16 @@ exports[`Html table render tests should match snapshot: Table with row and colum
 "[36m<div[39m
   [33mid[39m=[32m"test-4329874982374983798"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
+      [36m<br />[39m
+      [0m[0m
+    [36m</caption>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -1104,12 +1115,16 @@ exports[`Html table render tests should match snapshot: Table with row and colum
 "[36m<div[39m
   [33mid[39m=[32m"test-4329874982374983798"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
+      [36m<br />[39m
+      [0m[0m
+    [36m</caption>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -1739,7 +1754,9 @@ exports[`Html table render tests should match snapshot: Table with row and colum
 "[36m<div[39m
   [33mid[39m=[32m"test-4329874982374983798"[39m
 [36m>[39m
-  [36m<table>[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
+  [36m>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -2372,12 +2389,16 @@ exports[`Html table render tests should match snapshot: Table with row and colum
 "[36m<div[39m
   [33mid[39m=[32m"test-4329874982374983798"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mTiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto[0m
+      [36m<br />[39m
+      [0m[0m
+    [36m</caption>[39m
     [36m<thead>[39m
       [36m<tr>[39m
         [36m<td[39m
@@ -3004,12 +3025,16 @@ exports[`Html table render tests should match snapshot: Table with row variables
 "[36m<div[39m
   [33mid[39m=[32m"test-9483567287648723649867"[39m
 [36m>[39m
-  [36m<span[39m
-    [33mclass[39m=[32m"title"[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [0mLukumäärä 2022Q1-2022Q4 muuttujina Alue, Huoneluku, Rahoitusmuoto[0m
-  [36m</span>[39m
-  [36m<table>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mLukumäärä 2022Q1-2022Q4 muuttujina Alue, Huoneluku, Rahoitusmuoto[0m
+      [36m<br />[39m
+      [0m[0m
+    [36m</caption>[39m
     [36m<tbody>[39m
       [36m<tr>[39m
         [36m<th[39m

--- a/src/core/tables/htmlTable.ts
+++ b/src/core/tables/htmlTable.ts
@@ -10,27 +10,22 @@ export function renderHtmlTable(view: View, locale: string, showTitles: boolean,
     if (!container) throw new Error("No container with matching id found in the DOM tree");
 
     try {
-        if (showTitles) {
-            // Headings
-            const title = document.createElement('span');
-            title.classList.add('title');
-            title.append(view.header[locale]);
-            container.append(title);
-
-            if (view.subheaderValues.length > 0) {
-                const subtitle = document.createElement('span');
-                subtitle.classList.add('subtitle');
-                subtitle.append(view.subheaderValues.map(value => value[locale]).join(' | '));
-                container.append(subtitle);
-            }
-        }
-
         // Table content
         const table = generateTable(view, locale);
+
+        if (showTitles) {
+            const title: string = view.header[locale];
+            const subtitle: string = view.subheaderValues.map(value => value[locale]).join(' | ');
+            const caption = document.createElement('caption');
+            caption.className = 'tableChart-caption';
+            caption.append(title, document.createElement('br'), subtitle);
+            table.prepend(caption);
+        }
+
         container.append(table);
 
         // Units
-        if(showUnits) {
+        if (showUnits) {
             const pUnits = document.createElement('p');
             const unitName = getFormattedUnits(view.units, locale);
             const units: string = `${Translations.unit[locale]}: ${unitName}`;
@@ -39,7 +34,7 @@ export function renderHtmlTable(view: View, locale: string, showTitles: boolean,
         }
 
         // Sources
-        if(showSources) {
+        if (showSources) {
             const pSources = document.createElement('p');
             const sources: string = `${Translations.source[locale]}: ${view.sources.map(source => source[locale]).join(', ')}`;
             pSources.append(sources);
@@ -47,7 +42,7 @@ export function renderHtmlTable(view: View, locale: string, showTitles: boolean,
         }
 
         // Footnote
-        if(footnote) {
+        if (footnote) {
             const pFootnote = document.createElement('p');
             pFootnote.append(footnote);
             container.append(pFootnote);
@@ -66,7 +61,7 @@ export function generateTable(view: View, locale: string): HTMLTableElement {
     const colHeaderRows = view.columnNameGroups[0].length ?? 0;
     const rowHeaderCols = view.series[0].rowNameGroup.length ?? 0;
 
-    const table = document.createElement('table');
+    const table: HTMLTableElement = Object.assign(document.createElement('table'), { tabIndex: 0 });
 
     if (colHeaderRows > 0) {
         const columnHeaders = buildColumnHeaderRows(view.columnNameGroups, locale);

--- a/src/core/tables/htmlTable.ts
+++ b/src/core/tables/htmlTable.ts
@@ -15,10 +15,12 @@ export function renderHtmlTable(view: View, locale: string, showTitles: boolean,
 
         if (showTitles) {
             const title: string = view.header[locale];
-            const subtitle: string = view.subheaderValues.map(value => value[locale]).join(' | ');
             const caption = document.createElement('caption');
+            if (view.subheaderValues.length > 0) {
+                const subtitle: string = view.subheaderValues.map(value => value[locale]).join(' | ');
+                caption.append(title, document.createElement('br'), subtitle);
+            }
             caption.className = 'tableChart-caption';
-            caption.append(title, document.createElement('br'), subtitle);
             table.prepend(caption);
         }
 

--- a/src/react/components/burgerMenu/burgerMenu.test.tsx
+++ b/src/react/components/burgerMenu/burgerMenu.test.tsx
@@ -93,18 +93,18 @@ describe('burgerMenu, functional tests', () => {
         });
     });
 
-    it('Should calculate correct export dimensions for compliant input size', () => {
-        const mockRef = {
-            chart: {
-                chartWidth: 1200,
-                chartHeight: 800
-            }
-        } as HighchartsReactRefObject;
-
-        const { finalWidth, finalHeight } = calculateExportDimensions(mockRef);
-
-        expect(finalWidth).toEqual(1200);
-        expect(finalHeight).toEqual(800);
+    it('Should close the menu when ESC is pressed', async () => {
+        const view = convertPxGrafResponseToView(HORIZONTAL_BAR_CHART_ASCENDING, {});
+        render(<BurgerMenu locale="fi" viewData={view} />);
+        act(() => {
+            screen.getByRole('button').click();
+        });
+        await waitFor(() => {
+            window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        });
+        await waitFor(() => {
+            expect(screen.queryByLabelText('Kuvion valikko')).not.toBeNull();
+        });
     });
 
     it('Should calculate correct export dimensions when aspect ratio is too low', () => {

--- a/src/react/components/burgerMenu/burgerMenu.test.tsx
+++ b/src/react/components/burgerMenu/burgerMenu.test.tsx
@@ -44,7 +44,8 @@ describe('burgerMenu, functional tests', () => {
             screen.getByRole('button').click();
         });
         await waitFor(() => {
-            expect(screen.getAllByRole('button').length).toEqual(7);
+            expect(screen.getAllByRole('button').length).toEqual(5);
+            expect(screen.getAllByRole('link').length).toEqual(2);
             expect(screen.getByText('Lataa taulukko (csv)')).toBeTruthy();
             expect(screen.getByText('Lataa taulukko (xlsx)')).toBeTruthy();
             expect(screen.getByText('Foo')).toBeTruthy();
@@ -56,7 +57,7 @@ describe('burgerMenu, functional tests', () => {
         });
     });
 
-    it('Should invoke the custom function when clicked', async () => {
+    it('Should invoke the custom function and close the menu when button is clicked', async () => {
         const view = convertPxGrafResponseToView(HORIZONTAL_BAR_CHART_ASCENDING, {});
         const mockFunction = jest.fn();
         const btnText = 'Foo';
@@ -67,6 +68,28 @@ describe('burgerMenu, functional tests', () => {
         await waitFor(() => {
             screen.getByText(btnText).click();
             expect(mockFunction).toBeCalledTimes(1);
+        });
+        await waitFor(() => {
+            expect(screen.queryByText(btnText)).toBeNull();
+            expect(screen.queryByLabelText('Kuvion valikko')).not.toBeNull();
+        });
+    });
+
+    it('Should invoke the custom function and close the menu when link is clicked', async () => {
+        const view = convertPxGrafResponseToView(HORIZONTAL_BAR_CHART_ASCENDING, {});
+        const mockFunction = jest.fn();
+        const btnText = 'Foo';
+        render(<BurgerMenu locale="fi" viewData={view} menuItemDefinitions={[{ text: btnText, url: 'foobar.fi', isExternal: false, onClick: mockFunction }]} />);
+        act(() => {
+            screen.getByRole('button').click();
+        });
+        await waitFor(() => {
+            screen.getByText(btnText).click();
+            expect(mockFunction).toBeCalledTimes(1);
+        });
+        await waitFor(() => {
+            expect(screen.queryByText(btnText)).toBeNull();
+            expect(screen.queryByLabelText('Kuvion valikko')).not.toBeNull();
         });
     });
 

--- a/src/react/components/burgerMenu/burgerMenu.tsx
+++ b/src/react/components/burgerMenu/burgerMenu.tsx
@@ -138,7 +138,7 @@ export const BurgerMenu: React.FC<IBurgerMenuProps> = ({viewData, currentChartRe
         }
 
         if ('url' in menuItemDefinition) {
-            return <MenuItem isFirst={index === 0} bottomSeparator={index + 1 === menuItemDefinitions.length} locale={locale} prefixIcon={menuItemDefinition.prefixIcon} suffixIcon={menuItemDefinition.suffixIcon} isExternal={menuItemDefinition.isExternal} key={`customlmenuitem-${index}`} text={`${menuItemDefinition.text}`} url={menuItemDefinition.url} openNewTab={menuItemDefinition.openNewTab} />; // NOSONAR
+            return <MenuItem isFirst={index === 0} bottomSeparator={index + 1 === menuItemDefinitions.length} locale={locale} prefixIcon={menuItemDefinition.prefixIcon} suffixIcon={menuItemDefinition.suffixIcon} isExternal={menuItemDefinition.isExternal} key={`customlmenuitem-${index}`} text={`${menuItemDefinition.text}`} url={menuItemDefinition.url} openNewTab={menuItemDefinition.openNewTab} onClick={() => handleMenuItemClick()} />; // NOSONAR
         }
     });
 
@@ -159,10 +159,10 @@ export const BurgerMenu: React.FC<IBurgerMenuProps> = ({viewData, currentChartRe
     }
 
     const buttonRef = React.useRef<HTMLButtonElement>(null);
-    const handleMenuItemClick = (onClick: () => void) => {
-        onClick();
+    const handleMenuItemClick = (onClick?: () => void) => {
         setIsOpen(false);
         buttonRef.current?.focus();
+        if (onClick) onClick();
     }
 
     return (

--- a/src/react/components/burgerMenu/menuItem/__snapshots__/menuItem.test.tsx.snap
+++ b/src/react/components/burgerMenu/menuItem/__snapshots__/menuItem.test.tsx.snap
@@ -12,9 +12,9 @@ exports[`MenuItem, rendering tests should render 1`] = `
   display: inline;
   font-family: "Barlow Semi Condensed",Verdana,sans-serif;
   min-width: 14rem;
-  border-bottom: 0px;
   color: #1a3061;
   min-height: 3rem;
+  font-size: 0.75rem;
 }
 
 .c1:hover {
@@ -27,6 +27,7 @@ exports[`MenuItem, rendering tests should render 1`] = `
   border-top-left-radius: 0px;
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
+  border-bottom: 0px;
 }
 
 .c0:hover {
@@ -94,9 +95,9 @@ exports[`MenuItem, rendering tests should render with correct custom suffix icon
   display: inline;
   font-family: "Barlow Semi Condensed",Verdana,sans-serif;
   min-width: 14rem;
-  border-bottom: 0px;
   color: #1a3061;
   min-height: 3rem;
+  font-size: 0.75rem;
 }
 
 .c1:hover {
@@ -109,6 +110,7 @@ exports[`MenuItem, rendering tests should render with correct custom suffix icon
   border-top-left-radius: 0px;
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
+  border-bottom: 0px;
 }
 
 .c0:hover {
@@ -180,29 +182,23 @@ exports[`MenuItem, rendering tests should render with correct custom suffix icon
 
 exports[`MenuItem, rendering tests should render with correct external icon 1`] = `
 <DocumentFragment>
-  .c2 {
-  background-color: transparent;
-  text-align: left;
-  border: none;
-  margin: 0;
-  padding: 0.5rem 0.7rem 0.5rem 0.7rem;
-  cursor: pointer;
-  display: inline;
-  font-family: "Barlow Semi Condensed",Verdana,sans-serif;
-  min-width: 14rem;
-  border-bottom: 0px;
-  color: #1a3061;
-  min-height: 3rem;
-}
-
-.c2:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c1 {
+  .c1 {
   -webkit-text-decoration: none;
   text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.5rem 0.7rem;
+  min-width: 14rem;
+  font-family: "Barlow Semi Condensed",Verdana,sans-serif;
+  color: #1a3061;
+  min-height: 3rem;
+  font-size: 0.75rem;
 }
 
 .c1:hover {
@@ -215,13 +211,14 @@ exports[`MenuItem, rendering tests should render with correct external icon 1`] 
   border-top-left-radius: 0px;
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
+  border-bottom: 0px;
 }
 
 .c0:hover {
   background-color: #f2f2f2;
 }
 
-.c3 {
+.c2 {
   height: 100%;
   width: 100%;
   display: -webkit-box;
@@ -245,23 +242,23 @@ exports[`MenuItem, rendering tests should render with correct external icon 1`] 
   justify-items: center;
 }
 
-.c6 {
+.c5 {
   height: 1rem;
   width: 1rem;
 }
 
-.c6 svg {
+.c5 svg {
   height: 1rem;
   width: 1rem;
   fill: #1a3061;
 }
 
-.c4 {
+.c3 {
   margin-left: 0px;
   margin-right: 0.5rem;
 }
 
-.c5 {
+.c4 {
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(50%);
@@ -280,42 +277,38 @@ exports[`MenuItem, rendering tests should render with correct external icon 1`] 
       class="c1"
       href="foobar"
     >
-      <button
+      <div
         class="c2"
       >
-        <div
+        <span
           class="c3"
         >
-          <span
-            class="c4"
+          NAPPI
+        </span>
+        <span
+          class="c4"
+        >
+          Ulkoinen linkki
+        </span>
+        <div
+          class="c5"
+        >
+          <svg
+            aria-hidden="true"
+            height="79.62mm"
+            viewBox="0 0 251.84 225.69"
+            width="88.84mm"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            NAPPI
-          </span>
-          <span
-            class="c5"
-          >
-            Ulkoinen linkki
-          </span>
-          <div
-            class="c6"
-          >
-            <svg
-              aria-hidden="true"
-              height="79.62mm"
-              viewBox="0 0 251.84 225.69"
-              width="88.84mm"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m125.89,225.68c-22.84,0-45.67.03-68.51,0C23.18,225.63.03,202.4.01,168.14,0,131.14,0,94.13.01,57.13.04,23.53,23.35.14,56.85.1c23.67-.03,21.34.02,45.01-.03,4.75,0,8.96,1.04,11.87,5.09,2.64,3.67,3.08,7.7,1.25,11.83-2.01,4.53-5.59,7-10.57,7.06-9,.11-12,.07-21,.07-15.84,0-11.67-.05-27.5.02-18.82.08-31.81,12.98-31.84,31.74-.06,38-.06,76.01,0,114.01.03,18.74,13.04,31.7,31.86,31.72,46.67.05,93.34.06,140.01,0,18.79-.02,31.71-12.99,31.79-31.8.07-17,0-14,.03-31.01.02-8.3,4.75-13.75,11.83-13.81,7.07-.06,12.12,5.48,12.16,13.61.07,17.5.18,15.01-.02,32.51-.34,30.71-23.87,54.02-54.81,54.56h-71.01l-.02.02Z"
-              />
-              <path
-                d="m207.19,24.08c-6.95,0-23.9.04-30.85,0-8.12-.06-13.27-4.55-13.44-11.6-.17-7.19,5.18-12.33,13.32-12.38,17.33-.11,44.67-.12,62,0,8.48.06,13.45,4.99,13.5,13.37.12,16.83.12,43.67,0,60.5-.06,7.69-5.4,13.04-12.34,12.87-6.83-.17-11.53-5.35-11.61-12.97-.08-7.63-.02-25.26-.02-34.12-2.09,1.8-3.42,2.88-4.68,4.03-26.76,24.57-53.52,49.15-80.28,73.72-1.6,1.47-3.13,3-4.82,4.36-5.57,4.47-12.54,3.94-16.98-1.2-4.31-4.98-4.06-11.78,1.06-16.6,10.92-10.28,22.03-20.36,33.07-30.51,16.56-15.23,33.13-30.45,49.72-45.65.97-.89,2.15-1.56,3.23-2.33-.29-.5-.58-.99-.87-1.49h0Z"
-              />
-            </svg>
-          </div>
+            <path
+              d="m125.89,225.68c-22.84,0-45.67.03-68.51,0C23.18,225.63.03,202.4.01,168.14,0,131.14,0,94.13.01,57.13.04,23.53,23.35.14,56.85.1c23.67-.03,21.34.02,45.01-.03,4.75,0,8.96,1.04,11.87,5.09,2.64,3.67,3.08,7.7,1.25,11.83-2.01,4.53-5.59,7-10.57,7.06-9,.11-12,.07-21,.07-15.84,0-11.67-.05-27.5.02-18.82.08-31.81,12.98-31.84,31.74-.06,38-.06,76.01,0,114.01.03,18.74,13.04,31.7,31.86,31.72,46.67.05,93.34.06,140.01,0,18.79-.02,31.71-12.99,31.79-31.8.07-17,0-14,.03-31.01.02-8.3,4.75-13.75,11.83-13.81,7.07-.06,12.12,5.48,12.16,13.61.07,17.5.18,15.01-.02,32.51-.34,30.71-23.87,54.02-54.81,54.56h-71.01l-.02.02Z"
+            />
+            <path
+              d="m207.19,24.08c-6.95,0-23.9.04-30.85,0-8.12-.06-13.27-4.55-13.44-11.6-.17-7.19,5.18-12.33,13.32-12.38,17.33-.11,44.67-.12,62,0,8.48.06,13.45,4.99,13.5,13.37.12,16.83.12,43.67,0,60.5-.06,7.69-5.4,13.04-12.34,12.87-6.83-.17-11.53-5.35-11.61-12.97-.08-7.63-.02-25.26-.02-34.12-2.09,1.8-3.42,2.88-4.68,4.03-26.76,24.57-53.52,49.15-80.28,73.72-1.6,1.47-3.13,3-4.82,4.36-5.57,4.47-12.54,3.94-16.98-1.2-4.31-4.98-4.06-11.78,1.06-16.6,10.92-10.28,22.03-20.36,33.07-30.51,16.56-15.23,33.13-30.45,49.72-45.65.97-.89,2.15-1.56,3.23-2.33-.29-.5-.58-.99-.87-1.49h0Z"
+            />
+          </svg>
         </div>
-      </button>
+      </div>
     </a>
   </li>
 </DocumentFragment>
@@ -333,9 +326,9 @@ exports[`MenuItem, rendering tests should render with correct prefix icon 1`] = 
   display: inline;
   font-family: "Barlow Semi Condensed",Verdana,sans-serif;
   min-width: 14rem;
-  border-bottom: 0px;
   color: #1a3061;
   min-height: 3rem;
+  font-size: 0.75rem;
 }
 
 .c1:hover {
@@ -348,6 +341,7 @@ exports[`MenuItem, rendering tests should render with correct prefix icon 1`] = 
   border-top-left-radius: 0px;
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
+  border-bottom: 0px;
 }
 
 .c0:hover {
@@ -444,9 +438,9 @@ exports[`MenuItem, rendering tests should render with correct suffix icon 1`] = 
   display: inline;
   font-family: "Barlow Semi Condensed",Verdana,sans-serif;
   min-width: 14rem;
-  border-bottom: 0px;
   color: #1a3061;
   min-height: 3rem;
+  font-size: 0.75rem;
 }
 
 .c1:hover {
@@ -459,6 +453,7 @@ exports[`MenuItem, rendering tests should render with correct suffix icon 1`] = 
   border-top-left-radius: 0px;
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
+  border-bottom: 0px;
 }
 
 .c0:hover {

--- a/src/react/components/burgerMenu/menuItem/menuItem.test.tsx
+++ b/src/react/components/burgerMenu/menuItem/menuItem.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MenuItem } from "./menuItem";
-import React from "react";
+import React, { act } from "react";
 import 'jest-styled-components';
 
 const mockFunction = jest.fn();
@@ -33,13 +33,17 @@ describe('MenuItem, rendering tests', () => {
 });
 
 describe('MenuItem, functional tests', () => {
+    beforeEach(() => {
+        mockFunction.mockClear();
+    });
+
     it('should call onclick function when clicked', () => {
         const btnText = 'PRESSME';
         render(<MenuItem locale={'fi'} text={btnText} onClick={mockFunction} />);
         screen.getByText(btnText).click();
-        expect(mockFunction).toBeCalledTimes(1);
+        expect(mockFunction).toHaveBeenCalledTimes(1);
         screen.getByText(btnText).click();
-        expect(mockFunction).toBeCalledTimes(2);
+        expect(mockFunction).toHaveBeenCalledTimes(2);
     });
 
     it('should render a link that calls onclick function when clicked', () => {
@@ -47,7 +51,17 @@ describe('MenuItem, functional tests', () => {
         render(<MenuItem locale={'fi'} text={btnText} url={'foobar.fi'} openNewTab={true} onClick={mockFunction} />);
         expect(screen.getAllByRole('link').length).toBe(1);
         screen.getByText(btnText).click();
-        expect(mockFunction).toBeCalledTimes(3);
+        expect(mockFunction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onclick function when spacebar is pressed', () => {
+        const btnText = 'PRESSME';
+        render(<MenuItem locale={'fi'} text={btnText} url={'foobar.fi'} openNewTab={true} onClick={mockFunction} />);
+        screen.getByText(btnText).focus();
+        act(() => {
+            fireEvent.keyDown(screen.getByText(btnText), { key: ' ' });
+        });
+        expect(mockFunction).toHaveBeenCalledTimes(1);
     });
 
     it('should render nothing if functionality is not declared', () => {

--- a/src/react/components/burgerMenu/menuItem/menuItem.test.tsx
+++ b/src/react/components/burgerMenu/menuItem/menuItem.test.tsx
@@ -42,10 +42,12 @@ describe('MenuItem, functional tests', () => {
         expect(mockFunction).toBeCalledTimes(2);
     });
 
-    it('should render a link', () => {
+    it('should render a link that calls onclick function when clicked', () => {
         const btnText = 'PRESSME';
-        render(<MenuItem locale={'fi'} text={btnText} url={'foobar.fi'} openNewTab={true} />);
+        render(<MenuItem locale={'fi'} text={btnText} url={'foobar.fi'} openNewTab={true} onClick={mockFunction} />);
         expect(screen.getAllByRole('link').length).toBe(1);
+        screen.getByText(btnText).click();
+        expect(mockFunction).toBeCalledTimes(3);
     });
 
     it('should render nothing if functionality is not declared', () => {

--- a/src/react/components/burgerMenu/menuItem/menuItem.tsx
+++ b/src/react/components/burgerMenu/menuItem/menuItem.tsx
@@ -3,14 +3,10 @@ import styled from "styled-components";
 import { TIcon, allIcons } from "../../../../core/types/icon";
 import { Icon } from "../../icon/icon";
 import { Translations } from "../../../../core/conversion/translations";
-
-interface IButtonProps {
-    $separator?: boolean;
-}
-
 interface IListItemProps {
     $isFirst?: boolean;
     $isLast?: boolean;
+    $separator?: boolean;
 }
 
 interface ITextWrapperProps {
@@ -18,8 +14,7 @@ interface ITextWrapperProps {
     $hasSuffixIcon?: boolean;
 }
 
-
-const Button = styled.button<IButtonProps>`
+const Button = styled.button`
     background-color: transparent;
     text-align: left;
     border: none;
@@ -29,9 +24,9 @@ const Button = styled.button<IButtonProps>`
     display: inline;
     font-family: "Barlow Semi Condensed", Verdana, sans-serif;
     min-width: 14rem;
-    border-bottom: ${p => p.$separator ? '1px solid #bdbdbd' : '0px'};
     color: #1a3061;
     min-height: 3rem;
+    font-size: 0.75rem;
     :hover {
         text-decoration: underline;
     }
@@ -39,6 +34,14 @@ const Button = styled.button<IButtonProps>`
 
 const StyledLink = styled.a`
     text-decoration: none;
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.7rem;
+    min-width: 14rem;
+    font-family: "Barlow Semi Condensed", Verdana, sans-serif;
+    color: #1a3061;
+    min-height: 3rem;
+    font-size: 0.75rem;
     :hover {
         text-decoration: underline;
     }
@@ -49,6 +52,7 @@ const ListItem = styled.li<IListItemProps>`
     border-top-left-radius: ${p => p.$isFirst ? '18px' : '0px'};
     border-bottom-right-radius: ${p => p.$isLast ? '18px' : '0px'};
     border-bottom-left-radius: ${p => p.$isLast ? '18px' : '0px'};
+    border-bottom: ${p => p.$separator ? '1px solid #bdbdbd' : '0px'};
     :hover {
         background-color: #f2f2f2;
     }
@@ -116,6 +120,20 @@ export const MenuItem: React.FC<IMenuItemProps> = ({text, onClick, url, openNewT
         suffixIconContent = (typeof suffixIcon === 'string' && allIcons.includes(suffixIcon as TIcon)) ? <Icon inheritColor={true} icon={suffixIcon as TIcon} /> : prefixIcon;
     }
 
+    const handleLinkActivation = (e: React.MouseEvent | React.KeyboardEvent) => {
+        if (onClick) {
+            onClick();
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+        if (e.key === ' ') {
+            e.preventDefault();
+            handleLinkActivation(e);
+            (e.target as HTMLAnchorElement).click();
+        }
+    };
+
     const content = (
         <ContentWrapper>
             {
@@ -131,13 +149,18 @@ export const MenuItem: React.FC<IMenuItemProps> = ({text, onClick, url, openNewT
         </ContentWrapper>
     )
 
+    if (url) {
+        return (
+            <ListItem $isFirst={isFirst} $isLast={isLast} $separator={bottomSeparator}>
+                <StyledLink href={url} target={openNewTab ? '_blank' : undefined} onKeyDown={handleKeyDown} onClick={handleLinkActivation}>
+                    {content}
+                </StyledLink>
+            </ListItem>
+        );
+    }
+
     if (onClick) {
-        return (<ListItem $isFirst={isFirst} $isLast={isLast}><Button $separator={bottomSeparator} onClick={() => onClick()}>{content}</Button></ListItem>)
-    } else if (url) {
-        if (openNewTab) {
-            return (<ListItem $isFirst={isFirst} $isLast={isLast}><StyledLink href={url} target={'_blank'}><Button $separator={bottomSeparator}>{content}</Button></StyledLink></ListItem>);
-        }
-        return (<ListItem $isFirst={isFirst} $isLast={isLast}><StyledLink href={url}><Button $separator={bottomSeparator}>{content}</Button></StyledLink></ListItem>)
+        return (<ListItem $isFirst={isFirst} $isLast={isLast} $separator={bottomSeparator}><Button onClick={() => onClick()}>{content}</Button></ListItem>)
     }
     return (<></>);
 };

--- a/src/react/components/burgerMenu/menuItem/menuItem.tsx
+++ b/src/react/components/burgerMenu/menuItem/menuItem.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { TIcon, allIcons } from "../../../../core/types/icon";
 import { Icon } from "../../icon/icon";
 import { Translations } from "../../../../core/conversion/translations";
+
 interface IListItemProps {
     $isFirst?: boolean;
     $isLast?: boolean;
@@ -120,17 +121,16 @@ export const MenuItem: React.FC<IMenuItemProps> = ({text, onClick, url, openNewT
         suffixIconContent = (typeof suffixIcon === 'string' && allIcons.includes(suffixIcon as TIcon)) ? <Icon inheritColor={true} icon={suffixIcon as TIcon} /> : prefixIcon;
     }
 
-    const handleLinkActivation = (e: React.MouseEvent | React.KeyboardEvent) => {
-        if (onClick) {
-            onClick();
-        }
-    };
-
     const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
         if (e.key === ' ') {
             e.preventDefault();
-            handleLinkActivation(e);
             (e.target as HTMLAnchorElement).click();
+        }
+    };
+
+    const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        if (onClick) {
+            onClick();
         }
     };
 
@@ -152,7 +152,7 @@ export const MenuItem: React.FC<IMenuItemProps> = ({text, onClick, url, openNewT
     if (url) {
         return (
             <ListItem $isFirst={isFirst} $isLast={isLast} $separator={bottomSeparator}>
-                <StyledLink href={url} target={openNewTab ? '_blank' : undefined} onKeyDown={handleKeyDown} onClick={handleLinkActivation}>
+                <StyledLink href={url} target={openNewTab ? '_blank' : undefined} onKeyDown={handleKeyDown} onClick={handleClick}>
                     {content}
                 </StyledLink>
             </ListItem>
@@ -160,7 +160,7 @@ export const MenuItem: React.FC<IMenuItemProps> = ({text, onClick, url, openNewT
     }
 
     if (onClick) {
-        return (<ListItem $isFirst={isFirst} $isLast={isLast} $separator={bottomSeparator}><Button onClick={() => onClick()}>{content}</Button></ListItem>)
+        return (<ListItem $isFirst={isFirst} $isLast={isLast} $separator={bottomSeparator}><Button onClick={onClick}>{content}</Button></ListItem>)
     }
     return (<></>);
 };

--- a/src/react/components/chart/__snapshots__/chart.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/chart.test.tsx.snap
@@ -59,10 +59,7 @@ exports[`Rendering test renders chart data correctly 1`] = `
         >
           <caption
             class="tableChart-caption"
-          >
-            Lukumäärä, Pääkaupunkiseutu (PKS), Yksiöt 2015Q1-2015Q2 muuttujana Rahoitusmuoto
-            <br />
-          </caption>
+          />
           <thead>
             <tr>
               <td
@@ -2208,10 +2205,7 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
       >
         <caption
           class="tableChart-caption"
-        >
-          Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
-          <br />
-        </caption>
+        />
         <thead>
           <tr>
             <td

--- a/src/react/components/chart/__snapshots__/chart.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/chart.test.tsx.snap
@@ -54,12 +54,15 @@ exports[`Rendering test renders chart data correctly 1`] = `
         class="tableChart"
         id="foobar"
       >
-        <span
-          class="title"
+        <table
+          tabindex="0"
         >
-          Lukumäärä, Pääkaupunkiseutu (PKS), Yksiöt 2015Q1-2015Q2 muuttujana Rahoitusmuoto
-        </span>
-        <table>
+          <caption
+            class="tableChart-caption"
+          >
+            Lukumäärä, Pääkaupunkiseutu (PKS), Yksiöt 2015Q1-2015Q2 muuttujana Rahoitusmuoto
+            <br />
+          </caption>
           <thead>
             <tr>
               <td
@@ -175,7 +178,9 @@ exports[`Rendering test renders table data correctly 1`] = `
       class="tableChart"
       id="foobar"
     >
-      <table>
+      <table
+        tabindex="0"
+      >
         <thead>
           <tr>
             <td
@@ -846,7 +851,9 @@ exports[`Rendering test renders table data correctly when given footnote 1`] = `
       class="tableChart"
       id="foobar"
     >
-      <table>
+      <table
+        tabindex="0"
+      >
         <thead>
           <tr>
             <td
@@ -1520,7 +1527,9 @@ exports[`Rendering test renders table data correctly when sources are on 1`] = `
       class="tableChart"
       id="foobar"
     >
-      <table>
+      <table
+        tabindex="0"
+      >
         <thead>
           <tr>
             <td
@@ -2194,12 +2203,15 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
       class="tableChart"
       id="foobar"
     >
-      <span
-        class="title"
+      <table
+        tabindex="0"
       >
-        Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
-      </span>
-      <table>
+        <caption
+          class="tableChart-caption"
+        >
+          Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
+          <br />
+        </caption>
         <thead>
           <tr>
             <td
@@ -2870,7 +2882,9 @@ exports[`Rendering test renders table data correctly when units are on 1`] = `
       class="tableChart"
       id="foobar"
     >
-      <table>
+      <table
+        tabindex="0"
+      >
         <thead>
           <tr>
             <td

--- a/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
@@ -6,12 +6,15 @@ exports[`TableView render tests Should render correctly 1`] = `
     class="tableChart"
     id="foobar"
   >
-    <span
-      class="title"
+    <table
+      tabindex="0"
     >
-      Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
-    </span>
-    <table>
+      <caption
+        class="tableChart-caption"
+      >
+        Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
+        <br />
+      </caption>
       <thead>
         <tr>
           <td

--- a/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
@@ -11,10 +11,7 @@ exports[`TableView render tests Should render correctly 1`] = `
     >
       <caption
         class="tableChart-caption"
-      >
-        Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
-        <br />
-      </caption>
+      />
       <thead>
         <tr>
           <td

--- a/src/react/components/chart/chart.tsx
+++ b/src/react/components/chart/chart.tsx
@@ -8,7 +8,6 @@ import Highcharts from 'highcharts';
 import HighchartsReactOfficial, { HighchartsReact } from 'highcharts-react-official';
 import highchartsAccessibility from "highcharts/modules/accessibility.js";
 import highchartsExporting from 'highcharts/modules/exporting.js';
-import highchartsExportData from 'highcharts/modules/export-data.js';
 import highchartsOfflineExporting from 'highcharts/modules/offline-exporting.js';
 import { BurgerMenu, IFunctionalMenuItem, ILinkMenuItem } from "../burgerMenu/burgerMenu";
 import { extractSelectableVariableValues } from "../../../core/conversion/helpers";
@@ -31,7 +30,6 @@ const initializeHighcharts = (locale: string) => {
         });
         highchartsAccessibility(Highcharts);
         highchartsExporting(Highcharts);
-        highchartsExportData(Highcharts);
         highchartsOfflineExporting(Highcharts);
         Highcharts.setOptions(defaultTheme(locale));
     }

--- a/src/react/components/globalStyle/globalStyle.ts
+++ b/src/react/components/globalStyle/globalStyle.ts
@@ -60,4 +60,18 @@ export const GlobalStyle = createGlobalStyle`
         width: 90%;
         display: block;
     }
+
+    .tableChart .caption {
+        width: 90%;
+        display: block;
+        caption-side: top;
+    }
+
+    .tableChart-caption {
+        font-size: 1.25rem;
+        font-weight: 500;
+        color: #333;
+        margin-bottom: 2rem;
+        text-align: left;
+    }
 `;

--- a/src/stories/fixtures/verticalBarChart.ts
+++ b/src/stories/fixtures/verticalBarChart.ts
@@ -378,6 +378,7 @@ export const VERTICAL_BAR_CHART_WITH_CUSTOM_MENU_ITEMS: {
         {
             url: 'https://www.google.fi',
             text: 'Custom link',
+            
         }
     ]
 };


### PR DESCRIPTION
Converted table header fix - implemented as caption
TabIndex for tables makes it readable for NVDA
Removed export-data highcharts accessibility table option
Removed button from inside links in burger menu
Activating burger menu items or pressing "esc" closes the menu and refocuses on the menu button