### PR TITLE
Title - burger menu button overlap fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/highcharts/themes.ts
+++ b/src/core/highcharts/themes.ts
@@ -124,14 +124,18 @@ export const defaultTheme: (locale: string) => Highcharts.Options = (locale) => 
         }
     },
     title: {
+        useHTML: true, // HTML needs to be enabled for the title width to be restricted
         style: {
             color: '#000',
             fontSize: '1.25rem',
             fontWeight: '500',
-            textAlign: 'left'
+            textAlign: 'left',
+            maxWidth: 'calc(100% - 4rem)', // Restrict the width to leave space for the BurgerMenu
+            whiteSpace: 'normal', // Allow wrapping
         },
         align: 'left',
-        margin: 45
+        margin: 45,
+        minScale: 1,
     },
     subtitle: {
         style: {


### PR DESCRIPTION
UseHTML for title styling, less available space width wise to avoid overlapping with the burger menu button. MinSize of 1 to keep the font size consistent with the subtitle and force wrapping instead of resizing