### PR TITLE
Show title in tables by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,2 @@
+v1.3.0 (24 September 2025):
+- <Chart> component optional property 'showTableTitles' renamed to 'showTitles' as it now applies to both chart and table titles. Default value is true.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ drawChart(container, pxGraphData, locale);>
 - showContextMenu: boolean - Flag to show or hide the context menu in the visualization.
 - menuItemDefinitions: object[] - Definitions for custom context menu items. These can be either links or run custom functions. The provided object must implement either the IFunctionalMenuItem or ILinkMenuItem interface.
 - menuIconInheritColor: boolean - Flag to inherit the color of the context menu icons from the parent element.
-- showTitles: boolean - Flag to show or hide the titles in the table view.
+- showTitles: boolean - Flag to show or hide the titles in the tables and charts.
 - showTableUnits: boolean - Flag to show or hide the units in the table view.
 - showTableSources: boolean - Flag to show or hide the sources in the table view.
 - footnote: string - Custom footnote to be displayed in the visualization.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ drawChart(container, pxGraphData, locale);>
 - showContextMenu: boolean - Flag to show or hide the context menu in the visualization.
 - menuItemDefinitions: object[] - Definitions for custom context menu items. These can be either links or run custom functions. The provided object must implement either the IFunctionalMenuItem or ILinkMenuItem interface.
 - menuIconInheritColor: boolean - Flag to inherit the color of the context menu icons from the parent element.
-- showTableTitles: boolean - Flag to show or hide the titles in the table view.
+- showTitles: boolean - Flag to show or hide the titles in the table view.
 - showTableUnits: boolean - Flag to show or hide the units in the table view.
 - showTableSources: boolean - Flag to show or hide the sources in the table view.
 - footnote: string - Custom footnote to be displayed in the visualization.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/chartOptions/basicHorizontalBarchartOptions.ts
+++ b/src/core/chartOptions/basicHorizontalBarchartOptions.ts
@@ -6,7 +6,7 @@ import { IChartOptions } from '../types/chartOptions';
 
 export const basicHorizontalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     return {
-        ...commonHorizontalBarChartOptions(view, locale),
+        ...commonHorizontalBarChartOptions(view, locale, options),
         series: buildBarChartSeries(view, locale, false, options?.accessibilityMode),
         chart: { type: 'bar', spacingBottom: 60 },
         yAxis: {

--- a/src/core/chartOptions/chartOptions.ts
+++ b/src/core/chartOptions/chartOptions.ts
@@ -7,14 +7,15 @@ import { getLinearAxisTickPositionerFunction } from './Utility/tickPositioners';
 import { IChartOptions } from '../types/chartOptions';
 import { buildBarChartSeries, buildColumnChartSeries } from './Utility/seriesDataBuilder';
 
-export const commonChartOptions = (view: View, locale: string): Options  => {
+export const commonChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
+    const showTitle: boolean = options?.showTitle ?? true;
     return {
         accessibility: {
             point: {
                 descriptionFormatter: getScreenReaderFormatterCallbackFunction(view, locale)
             }
         },
-        title: { text: view.header[locale] },
+        title: { text: showTitle ? view.header[locale] : undefined },
         subtitle: { text: view.subheaderValues.map(sv => sv[locale]).join(' | ') },
         credits: { text: `${Translations.source[locale]}: ${view.sources.map(s => s[locale]).join(', ')}` },
         tooltip: {
@@ -65,9 +66,9 @@ export const commonBasicHorizontalBarChartYAxisOptions = (view: View, locale: st
     return yAxisOptions;
 }
 
-export const commonHorizontalBarChartOptions = (view: View, locale: string): Options => {
+export const commonHorizontalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     return {
-        ...commonChartOptions(view, locale),
+        ...commonChartOptions(view, locale, options),
         chart: { type: 'bar' },
         xAxis: {
             categories: view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', ')),
@@ -83,7 +84,7 @@ export const commonHorizontalBarChartOptions = (view: View, locale: string): Opt
 
 export const commonStackedHorizontalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     return {
-        ...commonHorizontalBarChartOptions(view, locale),
+        ...commonHorizontalBarChartOptions(view, locale, options),
         series: buildBarChartSeries(view, locale, true, options?.accessibilityMode),
         legend: {
             ...commonLegendStyleOptions,
@@ -95,9 +96,9 @@ export const commonStackedHorizontalBarChartOptions = (view: View, locale: strin
     };
 }
 
-export const commonVerticalBarChartOptions = (view: View, locale: string): Options => {
+export const commonVerticalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     const result = {
-        ...commonChartOptions(view, locale),
+        ...commonChartOptions(view, locale, options),
         chart: { type: 'column' },
         xAxis: getXAxisOptions(view, locale),
     };
@@ -106,7 +107,7 @@ export const commonVerticalBarChartOptions = (view: View, locale: string): Optio
 
 export const commonBasicVerticalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     return {
-        ...commonVerticalBarChartOptions(view, locale),
+        ...commonVerticalBarChartOptions(view, locale, options),
         series: buildColumnChartSeries(view, locale, false, options?.accessibilityMode),
         yAxis: {
             softMin: 0,
@@ -120,7 +121,7 @@ export const commonBasicVerticalBarChartOptions = (view: View, locale: string, o
 
 export const commonStackedVerticalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     return {
-        ...commonVerticalBarChartOptions(view, locale),
+        ...commonVerticalBarChartOptions(view, locale, options),
         series: buildColumnChartSeries(view, locale, true, options?.accessibilityMode),
         legend: {
             ...commonLegendStyleOptions,

--- a/src/core/chartOptions/groupHorizontalBarChartOptions.ts
+++ b/src/core/chartOptions/groupHorizontalBarChartOptions.ts
@@ -6,7 +6,7 @@ import { IChartOptions } from '../types/chartOptions';
 
 export const groupHorizontalBarChartOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     return {
-        ...commonHorizontalBarChartOptions(view, locale),
+        ...commonHorizontalBarChartOptions(view, locale, options),
         series: buildBarChartSeries(view, locale, false, options?.accessibilityMode),
         yAxis: {
             ...commonBasicHorizontalBarChartYAxisOptions(view, locale),

--- a/src/core/chartOptions/lineChartOptions.ts
+++ b/src/core/chartOptions/lineChartOptions.ts
@@ -10,7 +10,7 @@ export const lineChartOptions = (view: View, locale: string, options?: IChartOpt
     const cutValueAxis = !view.visualizationSettings?.cutValueAxis ? 0 : undefined;
     const markerSettings = options?.accessibilityMode ? { enabledThreshold: 3 } : { enabled: false };
     return {
-        ...commonChartOptions(view, locale),
+        ...commonChartOptions(view, locale, options),
         chart: { type: 'line' },
         tooltip: {
             formatter: getLineChartToolTipFormatterFunction(view, locale)

--- a/src/core/chartOptions/pyramidChartOptions.ts
+++ b/src/core/chartOptions/pyramidChartOptions.ts
@@ -9,7 +9,7 @@ export const pyramidChartOptions = (view: View, locale: string, options?: IChart
     const categories = view.columnNameGroups.map(cng => cng.map(n => n[locale]).join(', '));
     const maxValue = Math.max(...view.series.map(s => Math.max(...s.series.map(dataCell => dataCell.value ?? 0))));
     return {
-        ...commonChartOptions(view, locale),
+        ...commonChartOptions(view, locale, options),
         chart: { type: 'bar' },
         xAxis: {
             categories: categories,

--- a/src/core/chartOptions/scatterPlotOptions.ts
+++ b/src/core/chartOptions/scatterPlotOptions.ts
@@ -2,12 +2,13 @@ import { Options } from 'highcharts';
 import { IDataSeries, View } from "../types/view";
 import { getScatterPlotTooltipFormatterFunction } from './Utility/formatters';
 import { commonChartOptions, commonYAxisOptions } from './chartOptions';
+import { IChartOptions } from '../types/chartOptions';
 
-export const scatterPlotOptions = (view: View, locale: string): Options => {
+export const scatterPlotOptions = (view: View, locale: string, options?: IChartOptions): Options => {
     const X_INDEX = 1; const Y_INDEX = 0;
     const cutValueAxis = !view.visualizationSettings?.cutValueAxis ? 0 : undefined;
     return {
-        ...commonChartOptions(view, locale),
+        ...commonChartOptions(view, locale, options),
         chart: { type: 'scatter' },
         xAxis: {
             softMin: 0,

--- a/src/core/conversion/pxGrafDataConverter.ts
+++ b/src/core/conversion/pxGrafDataConverter.ts
@@ -41,7 +41,7 @@ export const convertPxGraphDataToChartOptions = (locale: string, view: View, opt
         case EVisualizationType.PyramidChart:
             return pyramidChartOptions(view, locale, options);
         case EVisualizationType.ScatterPlot:
-            return scatterPlotOptions(view, locale);
+            return scatterPlotOptions(view, locale, options);
         default:
             throw new Error('Unsupported chart type');
     }

--- a/src/core/types/chartOptions.ts
+++ b/src/core/types/chartOptions.ts
@@ -3,4 +3,5 @@
  */
 export interface IChartOptions {
     accessibilityMode?: boolean;
+    showTitle?: boolean;
 }

--- a/src/react/components/chart/__snapshots__/chart.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/chart.test.tsx.snap
@@ -115,28 +115,13 @@ exports[`Rendering test renders chart data correctly 1`] = `
             </tr>
           </tbody>
         </table>
-        <p>
-          Lähde: PxVisualizer-fi
-        </p>
       </div>
     </div>
   </div>
 </DocumentFragment>
 `;
 
-exports[`Rendering test renders error component on broken data 1`] = `
-<DocumentFragment>
-  <div
-    class="sc-cUiCeM eUmXth"
-  >
-    <h1>
-      Kuviota ei voitu muodostaa
-    </h1>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Rendering test renders table data correctly 1`] = `
+exports[`Rendering test renders chart data correctly with hidden title 1`] = `
 <DocumentFragment>
   <div
     class="sc-jScdur kXkHgn"
@@ -181,1999 +166,90 @@ exports[`Rendering test renders table data correctly 1`] = `
       </div>
     </div>
     <div
-      class="tableChart"
-      id="foobar"
+      class="sc-jPkiSJ iJnAtF"
     >
-      <table
-        tabindex="0"
-      >
-        <thead>
-          <tr>
-            <td
-              colspan="3"
-              rowspan="2"
-            />
-            <th
-              colspan="2"
-              scope="col"
-            >
-              Yksiöt
-            </th>
-            <th
-              colspan="2"
-              scope="col"
-            >
-              Kaksiot
-            </th>
-          </tr>
-          <tr>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Lukumäärä
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Neliövuokra (eur/m2)
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Lukumäärä
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Neliövuokra (eur/m2)
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Helsinki
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              13 021
-            </td>
-            <td>
-              26,64
-            </td>
-            <td>
-              10 080
-            </td>
-            <td>
-              20,22
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 810
-            </td>
-            <td>
-              15,90
-            </td>
-            <td>
-              6 176
-            </td>
-            <td>
-              13,74
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              11 231
-            </td>
-            <td>
-              26,82
-            </td>
-            <td>
-              9 326
-            </td>
-            <td>
-              20,45
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 552
-            </td>
-            <td>
-              15,97
-            </td>
-            <td>
-              5 749
-            </td>
-            <td>
-              13,78
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              10 269
-            </td>
-            <td>
-              26,93
-            </td>
-            <td>
-              8 907
-            </td>
-            <td>
-              20,59
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 249
-            </td>
-            <td>
-              15,99
-            </td>
-            <td>
-              5 280
-            </td>
-            <td>
-              13,79
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              10 272
-            </td>
-            <td>
-              26,93
-            </td>
-            <td>
-              8 805
-            </td>
-            <td>
-              20,66
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 323
-            </td>
-            <td>
-              16,08
-            </td>
-            <td>
-              5 265
-            </td>
-            <td>
-              13,80
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Vantaa
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              3 043
-            </td>
-            <td>
-              23,48
-            </td>
-            <td>
-              5 261
-            </td>
-            <td>
-              17,62
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              941
-            </td>
-            <td>
-              16,13
-            </td>
-            <td>
-              2 083
-            </td>
-            <td>
-              13,96
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 679
-            </td>
-            <td>
-              23,64
-            </td>
-            <td>
-              5 017
-            </td>
-            <td>
-              17,79
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              846
-            </td>
-            <td>
-              16,05
-            </td>
-            <td>
-              1 902
-            </td>
-            <td>
-              13,91
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 533
-            </td>
-            <td>
-              23,68
-            </td>
-            <td>
-              4 925
-            </td>
-            <td>
-              17,85
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              763
-            </td>
-            <td>
-              15,97
-            </td>
-            <td>
-              1 778
-            </td>
-            <td>
-              13,90
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 548
-            </td>
-            <td>
-              23,77
-            </td>
-            <td>
-              4 882
-            </td>
-            <td>
-              17,99
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              767
-            </td>
-            <td>
-              15,98
-            </td>
-            <td>
-              1 744
-            </td>
-            <td>
-              13,97
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Turku
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              5 534
-            </td>
-            <td>
-              18,16
-            </td>
-            <td>
-              4 267
-            </td>
-            <td>
-              14,07
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 292
-            </td>
-            <td>
-              13,91
-            </td>
-            <td>
-              1 782
-            </td>
-            <td>
-              11,81
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 437
-            </td>
-            <td>
-              18,32
-            </td>
-            <td>
-              3 666
-            </td>
-            <td>
-              14,27
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 149
-            </td>
-            <td>
-              14,02
-            </td>
-            <td>
-              1 642
-            </td>
-            <td>
-              11,87
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 014
-            </td>
-            <td>
-              18,44
-            </td>
-            <td>
-              3 329
-            </td>
-            <td>
-              14,37
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 107
-            </td>
-            <td>
-              14,06
-            </td>
-            <td>
-              1 554
-            </td>
-            <td>
-              11,86
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 195
-            </td>
-            <td>
-              18,53
-            </td>
-            <td>
-              3 414
-            </td>
-            <td>
-              14,48
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 161
-            </td>
-            <td>
-              14,11
-            </td>
-            <td>
-              1 557
-            </td>
-            <td>
-              11,96
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p>
-        Lähde: PxVisualizer-fi
-      </p>
+      <div />
     </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Rendering test renders table data correctly when given footnote 1`] = `
-<DocumentFragment>
-  <div
-    class="sc-jScdur kXkHgn"
-  >
     <div
-      class="sc-dcKlJK eEkQvl"
+      class="sc-cZSric gEMFNV"
     >
       <div
-        class="sc-kpOvIu imTYeK"
+        class="tableChart"
+        id="foobar"
       >
-        <button
-          aria-controls="«r5»-menu"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          aria-label="Kuvion valikko"
-          class="sc-icnseD Fbljb"
+        <table
+          tabindex="0"
         >
-          <svg
-            aria-hidden="true"
-            height="29.92mm"
-            viewBox="0 0 113.12 84.82"
-            width="39.91mm"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m56.51,14.13c-16.33,0-32.67.01-49,0-5.37,0-8.89-4.83-6.99-9.59C1.63,1.76,3.77.26,6.76.01c.22-.02.44,0,.66,0,32.74,0,65.49,0,98.23,0,4.3,0,7.45,2.99,7.47,7.01.02,4.11-3.15,7.1-7.6,7.11-16.33.01-32.67,0-49,0Z"
-              style="fill: #1A3061;"
-            />
-            <path
-              d="m56.55,49.47c-16.41,0-32.82.01-49.22,0-3.78,0-6.77-2.56-7.26-6.09-.49-3.53,1.78-6.9,5.35-7.81.77-.2,1.6-.21,2.4-.21,32.52,0,65.04-.01,97.57,0,4.51,0,7.69,2.89,7.74,6.97.04,4.19-3.16,7.14-7.79,7.15-16.26,0-32.52,0-48.78,0Z"
-              style="fill: #1A3061;"
-            />
-            <path
-              d="m56.43,84.82c-16.33,0-32.67,0-49,0-3.68,0-6.45-2.17-7.25-5.56-.73-3.09.92-6.54,3.92-7.84,1.04-.45,2.27-.69,3.41-.69,32.74-.04,65.49-.03,98.23-.02,4.27,0,7.41,3.06,7.39,7.09-.02,4.02-3.17,7.02-7.47,7.02-16.41.02-32.82,0-49.22,0Z"
-              style="fill: #1A3061;"
-            />
-          </svg>
-        </button>
-        <div
-          class="sc-jMsorb dfczEB"
-        />
+          <thead>
+            <tr>
+              <td
+                colspan="1"
+                rowspan="1"
+              />
+              <th
+                colspan="1"
+                scope="col"
+              >
+                2015Q1
+              </th>
+              <th
+                colspan="1"
+                scope="col"
+              >
+                2015Q2
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th
+                rowspan="1"
+                scope="row"
+              >
+                Vapaarahoitteinen
+              </th>
+              <td>
+                11 096
+              </td>
+              <td>
+                11 625
+              </td>
+            </tr>
+            <tr>
+              <th
+                rowspan="1"
+                scope="row"
+              >
+                ARA
+              </th>
+              <td>
+                4 845
+              </td>
+              <td>
+                5 174
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    </div>
-    <div
-      class="tableChart"
-      id="foobar"
-    >
-      <table
-        tabindex="0"
-      >
-        <thead>
-          <tr>
-            <td
-              colspan="3"
-              rowspan="2"
-            />
-            <th
-              colspan="2"
-              scope="col"
-            >
-              Yksiöt
-            </th>
-            <th
-              colspan="2"
-              scope="col"
-            >
-              Kaksiot
-            </th>
-          </tr>
-          <tr>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Lukumäärä
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Neliövuokra (eur/m2)
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Lukumäärä
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Neliövuokra (eur/m2)
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Helsinki
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              13 021
-            </td>
-            <td>
-              26,64
-            </td>
-            <td>
-              10 080
-            </td>
-            <td>
-              20,22
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 810
-            </td>
-            <td>
-              15,90
-            </td>
-            <td>
-              6 176
-            </td>
-            <td>
-              13,74
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              11 231
-            </td>
-            <td>
-              26,82
-            </td>
-            <td>
-              9 326
-            </td>
-            <td>
-              20,45
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 552
-            </td>
-            <td>
-              15,97
-            </td>
-            <td>
-              5 749
-            </td>
-            <td>
-              13,78
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              10 269
-            </td>
-            <td>
-              26,93
-            </td>
-            <td>
-              8 907
-            </td>
-            <td>
-              20,59
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 249
-            </td>
-            <td>
-              15,99
-            </td>
-            <td>
-              5 280
-            </td>
-            <td>
-              13,79
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              10 272
-            </td>
-            <td>
-              26,93
-            </td>
-            <td>
-              8 805
-            </td>
-            <td>
-              20,66
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 323
-            </td>
-            <td>
-              16,08
-            </td>
-            <td>
-              5 265
-            </td>
-            <td>
-              13,80
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Vantaa
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              3 043
-            </td>
-            <td>
-              23,48
-            </td>
-            <td>
-              5 261
-            </td>
-            <td>
-              17,62
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              941
-            </td>
-            <td>
-              16,13
-            </td>
-            <td>
-              2 083
-            </td>
-            <td>
-              13,96
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 679
-            </td>
-            <td>
-              23,64
-            </td>
-            <td>
-              5 017
-            </td>
-            <td>
-              17,79
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              846
-            </td>
-            <td>
-              16,05
-            </td>
-            <td>
-              1 902
-            </td>
-            <td>
-              13,91
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 533
-            </td>
-            <td>
-              23,68
-            </td>
-            <td>
-              4 925
-            </td>
-            <td>
-              17,85
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              763
-            </td>
-            <td>
-              15,97
-            </td>
-            <td>
-              1 778
-            </td>
-            <td>
-              13,90
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 548
-            </td>
-            <td>
-              23,77
-            </td>
-            <td>
-              4 882
-            </td>
-            <td>
-              17,99
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              767
-            </td>
-            <td>
-              15,98
-            </td>
-            <td>
-              1 744
-            </td>
-            <td>
-              13,97
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Turku
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              5 534
-            </td>
-            <td>
-              18,16
-            </td>
-            <td>
-              4 267
-            </td>
-            <td>
-              14,07
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 292
-            </td>
-            <td>
-              13,91
-            </td>
-            <td>
-              1 782
-            </td>
-            <td>
-              11,81
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 437
-            </td>
-            <td>
-              18,32
-            </td>
-            <td>
-              3 666
-            </td>
-            <td>
-              14,27
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 149
-            </td>
-            <td>
-              14,02
-            </td>
-            <td>
-              1 642
-            </td>
-            <td>
-              11,87
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 014
-            </td>
-            <td>
-              18,44
-            </td>
-            <td>
-              3 329
-            </td>
-            <td>
-              14,37
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 107
-            </td>
-            <td>
-              14,06
-            </td>
-            <td>
-              1 554
-            </td>
-            <td>
-              11,86
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 195
-            </td>
-            <td>
-              18,53
-            </td>
-            <td>
-              3 414
-            </td>
-            <td>
-              14,48
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 161
-            </td>
-            <td>
-              14,11
-            </td>
-            <td>
-              1 557
-            </td>
-            <td>
-              11,96
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p>
-        Test footnote
-      </p>
-      <p>
-        Lähde: PxVisualizer-fi
-      </p>
     </div>
   </div>
 </DocumentFragment>
 `;
 
-exports[`Rendering test renders table data correctly when sources are on 1`] = `
+exports[`Rendering test renders error component on broken data 1`] = `
 <DocumentFragment>
   <div
-    class="sc-jScdur kXkHgn"
+    class="sc-cUiCeM eUmXth"
   >
-    <div
-      class="sc-dcKlJK eEkQvl"
-    >
-      <div
-        class="sc-kpOvIu imTYeK"
-      >
-        <button
-          aria-controls="«r4»-menu"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          aria-label="Kuvion valikko"
-          class="sc-icnseD Fbljb"
-        >
-          <svg
-            aria-hidden="true"
-            height="29.92mm"
-            viewBox="0 0 113.12 84.82"
-            width="39.91mm"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m56.51,14.13c-16.33,0-32.67.01-49,0-5.37,0-8.89-4.83-6.99-9.59C1.63,1.76,3.77.26,6.76.01c.22-.02.44,0,.66,0,32.74,0,65.49,0,98.23,0,4.3,0,7.45,2.99,7.47,7.01.02,4.11-3.15,7.1-7.6,7.11-16.33.01-32.67,0-49,0Z"
-              style="fill: #1A3061;"
-            />
-            <path
-              d="m56.55,49.47c-16.41,0-32.82.01-49.22,0-3.78,0-6.77-2.56-7.26-6.09-.49-3.53,1.78-6.9,5.35-7.81.77-.2,1.6-.21,2.4-.21,32.52,0,65.04-.01,97.57,0,4.51,0,7.69,2.89,7.74,6.97.04,4.19-3.16,7.14-7.79,7.15-16.26,0-32.52,0-48.78,0Z"
-              style="fill: #1A3061;"
-            />
-            <path
-              d="m56.43,84.82c-16.33,0-32.67,0-49,0-3.68,0-6.45-2.17-7.25-5.56-.73-3.09.92-6.54,3.92-7.84,1.04-.45,2.27-.69,3.41-.69,32.74-.04,65.49-.03,98.23-.02,4.27,0,7.41,3.06,7.39,7.09-.02,4.02-3.17,7.02-7.47,7.02-16.41.02-32.82,0-49.22,0Z"
-              style="fill: #1A3061;"
-            />
-          </svg>
-        </button>
-        <div
-          class="sc-jMsorb dfczEB"
-        />
-      </div>
-    </div>
-    <div
-      class="tableChart"
-      id="foobar"
-    >
-      <table
-        tabindex="0"
-      >
-        <thead>
-          <tr>
-            <td
-              colspan="3"
-              rowspan="2"
-            />
-            <th
-              colspan="2"
-              scope="col"
-            >
-              Yksiöt
-            </th>
-            <th
-              colspan="2"
-              scope="col"
-            >
-              Kaksiot
-            </th>
-          </tr>
-          <tr>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Lukumäärä
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Neliövuokra (eur/m2)
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Lukumäärä
-            </th>
-            <th
-              colspan="1"
-              scope="col"
-            >
-              Neliövuokra (eur/m2)
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Helsinki
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              13 021
-            </td>
-            <td>
-              26,64
-            </td>
-            <td>
-              10 080
-            </td>
-            <td>
-              20,22
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 810
-            </td>
-            <td>
-              15,90
-            </td>
-            <td>
-              6 176
-            </td>
-            <td>
-              13,74
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              11 231
-            </td>
-            <td>
-              26,82
-            </td>
-            <td>
-              9 326
-            </td>
-            <td>
-              20,45
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 552
-            </td>
-            <td>
-              15,97
-            </td>
-            <td>
-              5 749
-            </td>
-            <td>
-              13,78
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              10 269
-            </td>
-            <td>
-              26,93
-            </td>
-            <td>
-              8 907
-            </td>
-            <td>
-              20,59
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 249
-            </td>
-            <td>
-              15,99
-            </td>
-            <td>
-              5 280
-            </td>
-            <td>
-              13,79
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              10 272
-            </td>
-            <td>
-              26,93
-            </td>
-            <td>
-              8 805
-            </td>
-            <td>
-              20,66
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              3 323
-            </td>
-            <td>
-              16,08
-            </td>
-            <td>
-              5 265
-            </td>
-            <td>
-              13,80
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Vantaa
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              3 043
-            </td>
-            <td>
-              23,48
-            </td>
-            <td>
-              5 261
-            </td>
-            <td>
-              17,62
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              941
-            </td>
-            <td>
-              16,13
-            </td>
-            <td>
-              2 083
-            </td>
-            <td>
-              13,96
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 679
-            </td>
-            <td>
-              23,64
-            </td>
-            <td>
-              5 017
-            </td>
-            <td>
-              17,79
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              846
-            </td>
-            <td>
-              16,05
-            </td>
-            <td>
-              1 902
-            </td>
-            <td>
-              13,91
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 533
-            </td>
-            <td>
-              23,68
-            </td>
-            <td>
-              4 925
-            </td>
-            <td>
-              17,85
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              763
-            </td>
-            <td>
-              15,97
-            </td>
-            <td>
-              1 778
-            </td>
-            <td>
-              13,90
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              2 548
-            </td>
-            <td>
-              23,77
-            </td>
-            <td>
-              4 882
-            </td>
-            <td>
-              17,99
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              767
-            </td>
-            <td>
-              15,98
-            </td>
-            <td>
-              1 744
-            </td>
-            <td>
-              13,97
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="8"
-              scope="row"
-            >
-              Turku
-            </th>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q1
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              5 534
-            </td>
-            <td>
-              18,16
-            </td>
-            <td>
-              4 267
-            </td>
-            <td>
-              14,07
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 292
-            </td>
-            <td>
-              13,91
-            </td>
-            <td>
-              1 782
-            </td>
-            <td>
-              11,81
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q2
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 437
-            </td>
-            <td>
-              18,32
-            </td>
-            <td>
-              3 666
-            </td>
-            <td>
-              14,27
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 149
-            </td>
-            <td>
-              14,02
-            </td>
-            <td>
-              1 642
-            </td>
-            <td>
-              11,87
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q3
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 014
-            </td>
-            <td>
-              18,44
-            </td>
-            <td>
-              3 329
-            </td>
-            <td>
-              14,37
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 107
-            </td>
-            <td>
-              14,06
-            </td>
-            <td>
-              1 554
-            </td>
-            <td>
-              11,86
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="2"
-              scope="row"
-            >
-              2022Q4
-            </th>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              Vapaarahoitteinen
-            </th>
-            <td>
-              4 195
-            </td>
-            <td>
-              18,53
-            </td>
-            <td>
-              3 414
-            </td>
-            <td>
-              14,48
-            </td>
-          </tr>
-          <tr>
-            <th
-              rowspan="1"
-              scope="row"
-            >
-              ARA
-            </th>
-            <td>
-              1 161
-            </td>
-            <td>
-              14,11
-            </td>
-            <td>
-              1 557
-            </td>
-            <td>
-              11,96
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p>
-        Lähde: PxVisualizer-fi
-      </p>
-    </div>
+    <h1>
+      Kuviota ei voitu muodostaa
+    </h1>
   </div>
 </DocumentFragment>
 `;
 
-exports[`Rendering test renders table data correctly when titles are forced on 1`] = `
+exports[`Rendering test renders table data correctly 1`] = `
 <DocumentFragment>
   <div
     class="sc-jScdur kXkHgn"
@@ -2848,6 +924,1369 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
           </tr>
         </tbody>
       </table>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Rendering test renders table data correctly when given footnote 1`] = `
+<DocumentFragment>
+  <div
+    class="sc-jScdur kXkHgn"
+  >
+    <div
+      class="sc-dcKlJK eEkQvl"
+    >
+      <div
+        class="sc-kpOvIu imTYeK"
+      >
+        <button
+          aria-controls="«r6»-menu"
+          aria-expanded="false"
+          aria-haspopup="menu"
+          aria-label="Kuvion valikko"
+          class="sc-icnseD Fbljb"
+        >
+          <svg
+            aria-hidden="true"
+            height="29.92mm"
+            viewBox="0 0 113.12 84.82"
+            width="39.91mm"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m56.51,14.13c-16.33,0-32.67.01-49,0-5.37,0-8.89-4.83-6.99-9.59C1.63,1.76,3.77.26,6.76.01c.22-.02.44,0,.66,0,32.74,0,65.49,0,98.23,0,4.3,0,7.45,2.99,7.47,7.01.02,4.11-3.15,7.1-7.6,7.11-16.33.01-32.67,0-49,0Z"
+              style="fill: #1A3061;"
+            />
+            <path
+              d="m56.55,49.47c-16.41,0-32.82.01-49.22,0-3.78,0-6.77-2.56-7.26-6.09-.49-3.53,1.78-6.9,5.35-7.81.77-.2,1.6-.21,2.4-.21,32.52,0,65.04-.01,97.57,0,4.51,0,7.69,2.89,7.74,6.97.04,4.19-3.16,7.14-7.79,7.15-16.26,0-32.52,0-48.78,0Z"
+              style="fill: #1A3061;"
+            />
+            <path
+              d="m56.43,84.82c-16.33,0-32.67,0-49,0-3.68,0-6.45-2.17-7.25-5.56-.73-3.09.92-6.54,3.92-7.84,1.04-.45,2.27-.69,3.41-.69,32.74-.04,65.49-.03,98.23-.02,4.27,0,7.41,3.06,7.39,7.09-.02,4.02-3.17,7.02-7.47,7.02-16.41.02-32.82,0-49.22,0Z"
+              style="fill: #1A3061;"
+            />
+          </svg>
+        </button>
+        <div
+          class="sc-jMsorb dfczEB"
+        />
+      </div>
+    </div>
+    <div
+      class="tableChart"
+      id="foobar"
+    >
+      <table
+        tabindex="0"
+      >
+        <caption
+          class="tableChart-caption"
+        >
+          Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
+        </caption>
+        <thead>
+          <tr>
+            <td
+              colspan="3"
+              rowspan="2"
+            />
+            <th
+              colspan="2"
+              scope="col"
+            >
+              Yksiöt
+            </th>
+            <th
+              colspan="2"
+              scope="col"
+            >
+              Kaksiot
+            </th>
+          </tr>
+          <tr>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Lukumäärä
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Neliövuokra (eur/m2)
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Lukumäärä
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Neliövuokra (eur/m2)
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Helsinki
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              13 021
+            </td>
+            <td>
+              26,64
+            </td>
+            <td>
+              10 080
+            </td>
+            <td>
+              20,22
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 810
+            </td>
+            <td>
+              15,90
+            </td>
+            <td>
+              6 176
+            </td>
+            <td>
+              13,74
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              11 231
+            </td>
+            <td>
+              26,82
+            </td>
+            <td>
+              9 326
+            </td>
+            <td>
+              20,45
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 552
+            </td>
+            <td>
+              15,97
+            </td>
+            <td>
+              5 749
+            </td>
+            <td>
+              13,78
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              10 269
+            </td>
+            <td>
+              26,93
+            </td>
+            <td>
+              8 907
+            </td>
+            <td>
+              20,59
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 249
+            </td>
+            <td>
+              15,99
+            </td>
+            <td>
+              5 280
+            </td>
+            <td>
+              13,79
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              10 272
+            </td>
+            <td>
+              26,93
+            </td>
+            <td>
+              8 805
+            </td>
+            <td>
+              20,66
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 323
+            </td>
+            <td>
+              16,08
+            </td>
+            <td>
+              5 265
+            </td>
+            <td>
+              13,80
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Vantaa
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              3 043
+            </td>
+            <td>
+              23,48
+            </td>
+            <td>
+              5 261
+            </td>
+            <td>
+              17,62
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              941
+            </td>
+            <td>
+              16,13
+            </td>
+            <td>
+              2 083
+            </td>
+            <td>
+              13,96
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 679
+            </td>
+            <td>
+              23,64
+            </td>
+            <td>
+              5 017
+            </td>
+            <td>
+              17,79
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              846
+            </td>
+            <td>
+              16,05
+            </td>
+            <td>
+              1 902
+            </td>
+            <td>
+              13,91
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 533
+            </td>
+            <td>
+              23,68
+            </td>
+            <td>
+              4 925
+            </td>
+            <td>
+              17,85
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              763
+            </td>
+            <td>
+              15,97
+            </td>
+            <td>
+              1 778
+            </td>
+            <td>
+              13,90
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 548
+            </td>
+            <td>
+              23,77
+            </td>
+            <td>
+              4 882
+            </td>
+            <td>
+              17,99
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              767
+            </td>
+            <td>
+              15,98
+            </td>
+            <td>
+              1 744
+            </td>
+            <td>
+              13,97
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Turku
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              5 534
+            </td>
+            <td>
+              18,16
+            </td>
+            <td>
+              4 267
+            </td>
+            <td>
+              14,07
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 292
+            </td>
+            <td>
+              13,91
+            </td>
+            <td>
+              1 782
+            </td>
+            <td>
+              11,81
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 437
+            </td>
+            <td>
+              18,32
+            </td>
+            <td>
+              3 666
+            </td>
+            <td>
+              14,27
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 149
+            </td>
+            <td>
+              14,02
+            </td>
+            <td>
+              1 642
+            </td>
+            <td>
+              11,87
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 014
+            </td>
+            <td>
+              18,44
+            </td>
+            <td>
+              3 329
+            </td>
+            <td>
+              14,37
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 107
+            </td>
+            <td>
+              14,06
+            </td>
+            <td>
+              1 554
+            </td>
+            <td>
+              11,86
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 195
+            </td>
+            <td>
+              18,53
+            </td>
+            <td>
+              3 414
+            </td>
+            <td>
+              14,48
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 161
+            </td>
+            <td>
+              14,11
+            </td>
+            <td>
+              1 557
+            </td>
+            <td>
+              11,96
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Test footnote
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Rendering test renders table data correctly when sources are on 1`] = `
+<DocumentFragment>
+  <div
+    class="sc-jScdur kXkHgn"
+  >
+    <div
+      class="sc-dcKlJK eEkQvl"
+    >
+      <div
+        class="sc-kpOvIu imTYeK"
+      >
+        <button
+          aria-controls="«r5»-menu"
+          aria-expanded="false"
+          aria-haspopup="menu"
+          aria-label="Kuvion valikko"
+          class="sc-icnseD Fbljb"
+        >
+          <svg
+            aria-hidden="true"
+            height="29.92mm"
+            viewBox="0 0 113.12 84.82"
+            width="39.91mm"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m56.51,14.13c-16.33,0-32.67.01-49,0-5.37,0-8.89-4.83-6.99-9.59C1.63,1.76,3.77.26,6.76.01c.22-.02.44,0,.66,0,32.74,0,65.49,0,98.23,0,4.3,0,7.45,2.99,7.47,7.01.02,4.11-3.15,7.1-7.6,7.11-16.33.01-32.67,0-49,0Z"
+              style="fill: #1A3061;"
+            />
+            <path
+              d="m56.55,49.47c-16.41,0-32.82.01-49.22,0-3.78,0-6.77-2.56-7.26-6.09-.49-3.53,1.78-6.9,5.35-7.81.77-.2,1.6-.21,2.4-.21,32.52,0,65.04-.01,97.57,0,4.51,0,7.69,2.89,7.74,6.97.04,4.19-3.16,7.14-7.79,7.15-16.26,0-32.52,0-48.78,0Z"
+              style="fill: #1A3061;"
+            />
+            <path
+              d="m56.43,84.82c-16.33,0-32.67,0-49,0-3.68,0-6.45-2.17-7.25-5.56-.73-3.09.92-6.54,3.92-7.84,1.04-.45,2.27-.69,3.41-.69,32.74-.04,65.49-.03,98.23-.02,4.27,0,7.41,3.06,7.39,7.09-.02,4.02-3.17,7.02-7.47,7.02-16.41.02-32.82,0-49.22,0Z"
+              style="fill: #1A3061;"
+            />
+          </svg>
+        </button>
+        <div
+          class="sc-jMsorb dfczEB"
+        />
+      </div>
+    </div>
+    <div
+      class="tableChart"
+      id="foobar"
+    >
+      <table
+        tabindex="0"
+      >
+        <caption
+          class="tableChart-caption"
+        >
+          Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
+        </caption>
+        <thead>
+          <tr>
+            <td
+              colspan="3"
+              rowspan="2"
+            />
+            <th
+              colspan="2"
+              scope="col"
+            >
+              Yksiöt
+            </th>
+            <th
+              colspan="2"
+              scope="col"
+            >
+              Kaksiot
+            </th>
+          </tr>
+          <tr>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Lukumäärä
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Neliövuokra (eur/m2)
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Lukumäärä
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Neliövuokra (eur/m2)
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Helsinki
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              13 021
+            </td>
+            <td>
+              26,64
+            </td>
+            <td>
+              10 080
+            </td>
+            <td>
+              20,22
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 810
+            </td>
+            <td>
+              15,90
+            </td>
+            <td>
+              6 176
+            </td>
+            <td>
+              13,74
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              11 231
+            </td>
+            <td>
+              26,82
+            </td>
+            <td>
+              9 326
+            </td>
+            <td>
+              20,45
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 552
+            </td>
+            <td>
+              15,97
+            </td>
+            <td>
+              5 749
+            </td>
+            <td>
+              13,78
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              10 269
+            </td>
+            <td>
+              26,93
+            </td>
+            <td>
+              8 907
+            </td>
+            <td>
+              20,59
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 249
+            </td>
+            <td>
+              15,99
+            </td>
+            <td>
+              5 280
+            </td>
+            <td>
+              13,79
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              10 272
+            </td>
+            <td>
+              26,93
+            </td>
+            <td>
+              8 805
+            </td>
+            <td>
+              20,66
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 323
+            </td>
+            <td>
+              16,08
+            </td>
+            <td>
+              5 265
+            </td>
+            <td>
+              13,80
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Vantaa
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              3 043
+            </td>
+            <td>
+              23,48
+            </td>
+            <td>
+              5 261
+            </td>
+            <td>
+              17,62
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              941
+            </td>
+            <td>
+              16,13
+            </td>
+            <td>
+              2 083
+            </td>
+            <td>
+              13,96
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 679
+            </td>
+            <td>
+              23,64
+            </td>
+            <td>
+              5 017
+            </td>
+            <td>
+              17,79
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              846
+            </td>
+            <td>
+              16,05
+            </td>
+            <td>
+              1 902
+            </td>
+            <td>
+              13,91
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 533
+            </td>
+            <td>
+              23,68
+            </td>
+            <td>
+              4 925
+            </td>
+            <td>
+              17,85
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              763
+            </td>
+            <td>
+              15,97
+            </td>
+            <td>
+              1 778
+            </td>
+            <td>
+              13,90
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 548
+            </td>
+            <td>
+              23,77
+            </td>
+            <td>
+              4 882
+            </td>
+            <td>
+              17,99
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              767
+            </td>
+            <td>
+              15,98
+            </td>
+            <td>
+              1 744
+            </td>
+            <td>
+              13,97
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Turku
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              5 534
+            </td>
+            <td>
+              18,16
+            </td>
+            <td>
+              4 267
+            </td>
+            <td>
+              14,07
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 292
+            </td>
+            <td>
+              13,91
+            </td>
+            <td>
+              1 782
+            </td>
+            <td>
+              11,81
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 437
+            </td>
+            <td>
+              18,32
+            </td>
+            <td>
+              3 666
+            </td>
+            <td>
+              14,27
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 149
+            </td>
+            <td>
+              14,02
+            </td>
+            <td>
+              1 642
+            </td>
+            <td>
+              11,87
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 014
+            </td>
+            <td>
+              18,44
+            </td>
+            <td>
+              3 329
+            </td>
+            <td>
+              14,37
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 107
+            </td>
+            <td>
+              14,06
+            </td>
+            <td>
+              1 554
+            </td>
+            <td>
+              11,86
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 195
+            </td>
+            <td>
+              18,53
+            </td>
+            <td>
+              3 414
+            </td>
+            <td>
+              14,48
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 161
+            </td>
+            <td>
+              14,11
+            </td>
+            <td>
+              1 557
+            </td>
+            <td>
+              11,96
+            </td>
+          </tr>
+        </tbody>
+      </table>
       <p>
         Lähde: PxVisualizer-fi
       </p>
@@ -2856,7 +2295,7 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
 </DocumentFragment>
 `;
 
-exports[`Rendering test renders table data correctly when units are on 1`] = `
+exports[`Rendering test renders table data correctly when titles are forced on 1`] = `
 <DocumentFragment>
   <div
     class="sc-jScdur kXkHgn"
@@ -2907,6 +2346,691 @@ exports[`Rendering test renders table data correctly when units are on 1`] = `
       <table
         tabindex="0"
       >
+        <caption
+          class="tableChart-caption"
+        >
+          Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
+        </caption>
+        <thead>
+          <tr>
+            <td
+              colspan="3"
+              rowspan="2"
+            />
+            <th
+              colspan="2"
+              scope="col"
+            >
+              Yksiöt
+            </th>
+            <th
+              colspan="2"
+              scope="col"
+            >
+              Kaksiot
+            </th>
+          </tr>
+          <tr>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Lukumäärä
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Neliövuokra (eur/m2)
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Lukumäärä
+            </th>
+            <th
+              colspan="1"
+              scope="col"
+            >
+              Neliövuokra (eur/m2)
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Helsinki
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              13 021
+            </td>
+            <td>
+              26,64
+            </td>
+            <td>
+              10 080
+            </td>
+            <td>
+              20,22
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 810
+            </td>
+            <td>
+              15,90
+            </td>
+            <td>
+              6 176
+            </td>
+            <td>
+              13,74
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              11 231
+            </td>
+            <td>
+              26,82
+            </td>
+            <td>
+              9 326
+            </td>
+            <td>
+              20,45
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 552
+            </td>
+            <td>
+              15,97
+            </td>
+            <td>
+              5 749
+            </td>
+            <td>
+              13,78
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              10 269
+            </td>
+            <td>
+              26,93
+            </td>
+            <td>
+              8 907
+            </td>
+            <td>
+              20,59
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 249
+            </td>
+            <td>
+              15,99
+            </td>
+            <td>
+              5 280
+            </td>
+            <td>
+              13,79
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              10 272
+            </td>
+            <td>
+              26,93
+            </td>
+            <td>
+              8 805
+            </td>
+            <td>
+              20,66
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              3 323
+            </td>
+            <td>
+              16,08
+            </td>
+            <td>
+              5 265
+            </td>
+            <td>
+              13,80
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Vantaa
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              3 043
+            </td>
+            <td>
+              23,48
+            </td>
+            <td>
+              5 261
+            </td>
+            <td>
+              17,62
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              941
+            </td>
+            <td>
+              16,13
+            </td>
+            <td>
+              2 083
+            </td>
+            <td>
+              13,96
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 679
+            </td>
+            <td>
+              23,64
+            </td>
+            <td>
+              5 017
+            </td>
+            <td>
+              17,79
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              846
+            </td>
+            <td>
+              16,05
+            </td>
+            <td>
+              1 902
+            </td>
+            <td>
+              13,91
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 533
+            </td>
+            <td>
+              23,68
+            </td>
+            <td>
+              4 925
+            </td>
+            <td>
+              17,85
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              763
+            </td>
+            <td>
+              15,97
+            </td>
+            <td>
+              1 778
+            </td>
+            <td>
+              13,90
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              2 548
+            </td>
+            <td>
+              23,77
+            </td>
+            <td>
+              4 882
+            </td>
+            <td>
+              17,99
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              767
+            </td>
+            <td>
+              15,98
+            </td>
+            <td>
+              1 744
+            </td>
+            <td>
+              13,97
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="8"
+              scope="row"
+            >
+              Turku
+            </th>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q1
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              5 534
+            </td>
+            <td>
+              18,16
+            </td>
+            <td>
+              4 267
+            </td>
+            <td>
+              14,07
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 292
+            </td>
+            <td>
+              13,91
+            </td>
+            <td>
+              1 782
+            </td>
+            <td>
+              11,81
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q2
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 437
+            </td>
+            <td>
+              18,32
+            </td>
+            <td>
+              3 666
+            </td>
+            <td>
+              14,27
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 149
+            </td>
+            <td>
+              14,02
+            </td>
+            <td>
+              1 642
+            </td>
+            <td>
+              11,87
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q3
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 014
+            </td>
+            <td>
+              18,44
+            </td>
+            <td>
+              3 329
+            </td>
+            <td>
+              14,37
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 107
+            </td>
+            <td>
+              14,06
+            </td>
+            <td>
+              1 554
+            </td>
+            <td>
+              11,86
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="2"
+              scope="row"
+            >
+              2022Q4
+            </th>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              Vapaarahoitteinen
+            </th>
+            <td>
+              4 195
+            </td>
+            <td>
+              18,53
+            </td>
+            <td>
+              3 414
+            </td>
+            <td>
+              14,48
+            </td>
+          </tr>
+          <tr>
+            <th
+              rowspan="1"
+              scope="row"
+            >
+              ARA
+            </th>
+            <td>
+              1 161
+            </td>
+            <td>
+              14,11
+            </td>
+            <td>
+              1 557
+            </td>
+            <td>
+              11,96
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Rendering test renders table data correctly when units and footnote are on 1`] = `
+<DocumentFragment>
+  <div
+    class="sc-jScdur kXkHgn"
+  >
+    <div
+      class="sc-dcKlJK eEkQvl"
+    >
+      <div
+        class="sc-kpOvIu imTYeK"
+      >
+        <button
+          aria-controls="«r4»-menu"
+          aria-expanded="false"
+          aria-haspopup="menu"
+          aria-label="Kuvion valikko"
+          class="sc-icnseD Fbljb"
+        >
+          <svg
+            aria-hidden="true"
+            height="29.92mm"
+            viewBox="0 0 113.12 84.82"
+            width="39.91mm"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m56.51,14.13c-16.33,0-32.67.01-49,0-5.37,0-8.89-4.83-6.99-9.59C1.63,1.76,3.77.26,6.76.01c.22-.02.44,0,.66,0,32.74,0,65.49,0,98.23,0,4.3,0,7.45,2.99,7.47,7.01.02,4.11-3.15,7.1-7.6,7.11-16.33.01-32.67,0-49,0Z"
+              style="fill: #1A3061;"
+            />
+            <path
+              d="m56.55,49.47c-16.41,0-32.82.01-49.22,0-3.78,0-6.77-2.56-7.26-6.09-.49-3.53,1.78-6.9,5.35-7.81.77-.2,1.6-.21,2.4-.21,32.52,0,65.04-.01,97.57,0,4.51,0,7.69,2.89,7.74,6.97.04,4.19-3.16,7.14-7.79,7.15-16.26,0-32.52,0-48.78,0Z"
+              style="fill: #1A3061;"
+            />
+            <path
+              d="m56.43,84.82c-16.33,0-32.67,0-49,0-3.68,0-6.45-2.17-7.25-5.56-.73-3.09.92-6.54,3.92-7.84,1.04-.45,2.27-.69,3.41-.69,32.74-.04,65.49-.03,98.23-.02,4.27,0,7.41,3.06,7.39,7.09-.02,4.02-3.17,7.02-7.47,7.02-16.41.02-32.82,0-49.22,0Z"
+              style="fill: #1A3061;"
+            />
+          </svg>
+        </button>
+        <div
+          class="sc-jMsorb dfczEB"
+        />
+      </div>
+    </div>
+    <div
+      class="tableChart"
+      id="foobar"
+    >
+      <table
+        tabindex="0"
+      >
+        <caption
+          class="tableChart-caption"
+        >
+          Tiedot 2022Q1-2022Q4 muuttujina Tiedot, Alue, Huoneluku, Rahoitusmuoto
+        </caption>
         <thead>
           <tr>
             <td
@@ -3530,7 +3654,7 @@ exports[`Rendering test renders table data correctly when units are on 1`] = `
         Yksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2
       </p>
       <p>
-        Lähde: PxVisualizer-fi
+        Test footnote
       </p>
     </div>
   </div>

--- a/src/react/components/chart/__snapshots__/chart.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/chart.test.tsx.snap
@@ -115,6 +115,9 @@ exports[`Rendering test renders chart data correctly 1`] = `
             </tr>
           </tbody>
         </table>
+        <p>
+          Lähde: PxVisualizer-fi
+        </p>
       </div>
     </div>
   </div>
@@ -231,6 +234,9 @@ exports[`Rendering test renders chart data correctly with hidden title 1`] = `
             </tr>
           </tbody>
         </table>
+        <p>
+          Lähde: PxVisualizer-fi
+        </p>
       </div>
     </div>
   </div>
@@ -924,6 +930,9 @@ exports[`Rendering test renders table data correctly 1`] = `
           </tr>
         </tbody>
       </table>
+      <p>
+        Lähde: PxVisualizer-fi
+      </p>
     </div>
   </div>
 </DocumentFragment>
@@ -1606,6 +1615,9 @@ exports[`Rendering test renders table data correctly when given footnote 1`] = `
       </table>
       <p>
         Test footnote
+      </p>
+      <p>
+        Lähde: PxVisualizer-fi
       </p>
     </div>
   </div>
@@ -2970,6 +2982,9 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
           </tr>
         </tbody>
       </table>
+      <p>
+        Lähde: PxVisualizer-fi
+      </p>
     </div>
   </div>
 </DocumentFragment>
@@ -3655,6 +3670,9 @@ exports[`Rendering test renders table data correctly when units and footnote are
       </p>
       <p>
         Test footnote
+      </p>
+      <p>
+        Lähde: PxVisualizer-fi
       </p>
     </div>
   </div>

--- a/src/react/components/chart/chart.test.tsx
+++ b/src/react/components/chart/chart.test.tsx
@@ -37,7 +37,7 @@ describe('Rendering test', () => {
             <Chart
                 pxGraphData={GROUP_VERTICAL_BAR_CHART_CHART_FIXTURE}
                 locale={'fi'}
-                showTableTitles={false}
+                showTitles={false}
                 
             />);
         expect(asFragment()).toMatchSnapshot();
@@ -57,7 +57,7 @@ describe('Rendering test', () => {
             <Chart
                 pxGraphData={TABLE_WITH_ROW_AND_COLUMN_VARIABLES_CHART_FIXTURE}
                 locale={'fi'}
-                showTableTitles={true}
+                showTitles={true}
             />);
         expect(asFragment()).toMatchSnapshot();
     });

--- a/src/react/components/chart/chart.test.tsx
+++ b/src/react/components/chart/chart.test.tsx
@@ -32,6 +32,17 @@ describe('Rendering test', () => {
         expect(asFragment()).toMatchSnapshot();
     });
 
+    it('renders chart data correctly with hidden title', () => {
+        const { asFragment } = render(
+            <Chart
+                pxGraphData={GROUP_VERTICAL_BAR_CHART_CHART_FIXTURE}
+                locale={'fi'}
+                showTableTitles={false}
+                
+            />);
+        expect(asFragment()).toMatchSnapshot();
+    });
+
     it('renders table data correctly', () => {
         const { asFragment } = render(
             <Chart
@@ -51,12 +62,13 @@ describe('Rendering test', () => {
         expect(asFragment()).toMatchSnapshot();
     });
 
-    it('renders table data correctly when units are on', () => {
+    it('renders table data correctly when units and footnote are on', () => {
         const { asFragment } = render(
             <Chart
                 pxGraphData={TABLE_WITH_ROW_AND_COLUMN_VARIABLES_CHART_FIXTURE}
                 locale={'fi'}
                 showTableUnits={true}
+                footnote='Test footnote'
             />);
         expect(asFragment()).toMatchSnapshot();
     });
@@ -82,7 +94,6 @@ describe('Rendering test', () => {
     });
 
     it('renders error component on broken data', () => {
-
         const spy = jest.spyOn(console, "error");
         spy.mockImplementation(() => { });
 

--- a/src/react/components/chart/chart.tsx
+++ b/src/react/components/chart/chart.tsx
@@ -149,7 +149,7 @@ const ReactChart: React.FC<IChartProps> = ({
     try {
         // Chart
         if (view && pxGraphData.visualizationSettings.visualizationType !== EVisualizationType.Table) {
-            const highChartOptions = convertPxGraphDataToChartOptions(validLocale, view, { accessibilityMode });
+            const highChartOptions = convertPxGraphDataToChartOptions(validLocale, view, { accessibilityMode: accessibilityMode, showTitle: showTableTitles ?? true });
             return (
                 <ChartWrapper>
                     {
@@ -163,10 +163,11 @@ const ReactChart: React.FC<IChartProps> = ({
                             ref={chartRef}
                             immutable={true}
                             highcharts={Highcharts}
-                            options={highChartOptions}/>
+                            options={highChartOptions}
+                        />
                     </ChartContainer>
                     <TableContainer $tableMode={tableMode}>
-                        <TableView showTitles={showTableTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={showTableSources ?? true} view={view} locale={validLocale} />
+                        <TableView showTitles={showTableTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
                     </TableContainer>
                 </ChartWrapper>
             );
@@ -182,7 +183,7 @@ const ReactChart: React.FC<IChartProps> = ({
                             <BurgerMenu menuItemDefinitions={menuItemDefinitions} viewData={view} locale={validLocale} menuIconInheritColor={menuIconInheritColor} />
                         </MenuContainer>
                     }
-                    <TableView showTitles={showTableTitles ?? false} footnote={footnote} showUnits={!!showTableUnits} showSources={showTableSources ?? true} view={view} locale={validLocale} />
+                    <TableView showTitles={showTableTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
                 </ChartWrapper>
             );
         }

--- a/src/react/components/chart/chart.tsx
+++ b/src/react/components/chart/chart.tsx
@@ -68,7 +68,7 @@ export interface IChartProps {
     showContextMenu?: boolean;
     menuItemDefinitions?: (IFunctionalMenuItem | ILinkMenuItem)[];
     menuIconInheritColor?: boolean;
-    showTableTitles?: boolean;
+    showTitles?: boolean;
     showTableUnits?: boolean;
     showTableSources?: boolean;
     footnote?: string;
@@ -82,7 +82,7 @@ const ReactChart: React.FC<IChartProps> = ({
     selectedVariableCodes = null,
     showContextMenu = true,
     menuIconInheritColor = false,
-    showTableTitles,
+    showTitles,
     showTableUnits,
     showTableSources}) => {
     const validLocale = formatLocale(locale);
@@ -149,7 +149,7 @@ const ReactChart: React.FC<IChartProps> = ({
     try {
         // Chart
         if (view && pxGraphData.visualizationSettings.visualizationType !== EVisualizationType.Table) {
-            const highChartOptions = convertPxGraphDataToChartOptions(validLocale, view, { accessibilityMode: accessibilityMode, showTitle: showTableTitles ?? true });
+            const highChartOptions = convertPxGraphDataToChartOptions(validLocale, view, { accessibilityMode: accessibilityMode, showTitle: showTitles ?? true });
             return (
                 <ChartWrapper>
                     {
@@ -167,7 +167,7 @@ const ReactChart: React.FC<IChartProps> = ({
                         />
                     </ChartContainer>
                     <TableContainer $tableMode={tableMode}>
-                        <TableView showTitles={showTableTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
+                        <TableView showTitles={showTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
                     </TableContainer>
                 </ChartWrapper>
             );
@@ -183,7 +183,7 @@ const ReactChart: React.FC<IChartProps> = ({
                             <BurgerMenu menuItemDefinitions={menuItemDefinitions} viewData={view} locale={validLocale} menuIconInheritColor={menuIconInheritColor} />
                         </MenuContainer>
                     }
-                    <TableView showTitles={showTableTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
+                    <TableView showTitles={showTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
                 </ChartWrapper>
             );
         }

--- a/src/react/components/chart/chart.tsx
+++ b/src/react/components/chart/chart.tsx
@@ -167,7 +167,7 @@ const ReactChart: React.FC<IChartProps> = ({
                         />
                     </ChartContainer>
                     <TableContainer $tableMode={tableMode}>
-                        <TableView showTitles={showTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
+                        <TableView showTitles={showTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={showTableSources ?? true} view={view} locale={validLocale} />
                     </TableContainer>
                 </ChartWrapper>
             );
@@ -183,7 +183,7 @@ const ReactChart: React.FC<IChartProps> = ({
                             <BurgerMenu menuItemDefinitions={menuItemDefinitions} viewData={view} locale={validLocale} menuIconInheritColor={menuIconInheritColor} />
                         </MenuContainer>
                     }
-                    <TableView showTitles={showTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={!!showTableSources} view={view} locale={validLocale} />
+                    <TableView showTitles={showTitles ?? true} footnote={footnote} showUnits={!!showTableUnits} showSources={showTableSources ?? true} view={view} locale={validLocale} />
                 </ChartWrapper>
             );
         }


### PR DESCRIPTION
Allows hiding title from charts by setting the optional showTableTitles prop to false. Tests updated accordingly.
Note! Includes a breaking change and thus raises minor version number to 1.3.0
- showTableTitles Chart parameter renamed to showTitles as it is now universally used between charts and tables