### PR TITLE
Source after footnote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/tables/__snapshots__/htmlTable.test.ts.snap
+++ b/src/core/tables/__snapshots__/htmlTable.test.ts.snap
@@ -3542,3 +3542,35 @@ exports[`Html table render tests should match snapshot: Table with row variables
   [36m</p>[39m
 [36m</div>[39m"
 `;
+
+exports[`Html table render tests should match snapshot: Table with source and footnote 1`] = `
+"[36m<div[39m
+  [33mid[39m=[32m"test-6895638450983059889"[39m
+[36m>[39m
+  [36m<table[39m
+    [33mtabindex[39m=[32m"0"[39m
+  [36m>[39m
+    [36m<caption[39m
+      [33mclass[39m=[32m"tableChart-caption"[39m
+    [36m>[39m
+      [0mLukumäärä, Vantaa, Yksiöt, Vapaarahoitteinen 2022Q4[0m
+    [36m</caption>[39m
+    [36m<tbody>[39m
+      [36m<tr>[39m
+        [36m<td>[39m
+          [0m2 548[0m
+        [36m</td>[39m
+      [36m</tr>[39m
+    [36m</tbody>[39m
+  [36m</table>[39m
+  [36m<p>[39m
+    [0mYksikkö: lukumäärä[0m
+  [36m</p>[39m
+  [36m<p>[39m
+    [0mTest footnote[0m
+  [36m</p>[39m
+  [36m<p>[39m
+    [0mLähde: PxVisualizer-fi[0m
+  [36m</p>[39m
+[36m</div>[39m"
+`;

--- a/src/core/tables/htmlTable.test.ts
+++ b/src/core/tables/htmlTable.test.ts
@@ -168,6 +168,29 @@ describe('Html table render tests', () => {
         document.body.removeChild(div);
     });
 
+    it('should match snapshot: Table with source and footnote', () => {
+        const mockVarSelections = extractSelectableVariableValues(
+            TABLE_WITH_ONE_CELL.pxGraphData.selectableVariableCodes,
+            TABLE_WITH_ONE_CELL.pxGraphData.metaData,
+            TABLE_WITH_ONE_CELL.pxGraphData.visualizationSettings.defaultSelectableVariableCodes,
+            TABLE_WITH_ONE_CELL.selectedVariableCodes);
+        const mockView = convertPxGrafResponseToView(TABLE_WITH_ONE_CELL.pxGraphData, mockVarSelections);
+        const locale = 'fi';
+
+        const testId = 'test-6895638450983059889';
+
+        const div = document.createElement('div');
+        div.id = testId;
+        document.body.appendChild(div);
+
+        renderHtmlTable(mockView, locale, true, true, true, testId, 'Test footnote');
+
+        const renderedOutput = prettyDOM(div);
+        expect(renderedOutput).toMatchSnapshot();
+
+        document.body.removeChild(div);
+    });
+
     it('should match snapshot: Table with missing data and selectable values', () => {
         const mockVarSelections = extractSelectableVariableValues(
             SELECTABLE_TABLE_WITH_MISSING_DATA.selectableVariableCodes,

--- a/src/core/tables/htmlTable.ts
+++ b/src/core/tables/htmlTable.ts
@@ -36,19 +36,19 @@ export function renderHtmlTable(view: View, locale: string, showTitles: boolean,
             container.append(pUnits);
         }
 
+        // Footnote
+        if (footnote) {
+            const pFootnote = document.createElement('p');
+            pFootnote.append(footnote);
+            container.append(pFootnote);
+        }
+
         // Sources
         if (showSources) {
             const pSources = document.createElement('p');
             const sources: string = `${Translations.source[locale]}: ${view.sources.map(source => source[locale]).join(', ')}`;
             pSources.append(sources);
             container.append(pSources);
-        }
-
-        // Footnote
-        if (footnote) {
-            const pFootnote = document.createElement('p');
-            pFootnote.append(footnote);
-            container.append(pFootnote);
         }
 
     } catch (error) {


### PR DESCRIPTION
Moves source information under footnote if both are provided for tables. Tests updated.