### PR TITLE
[Fix] Adds css styling for html table metadata section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/tables/__snapshots__/htmlTable.test.ts.snap
+++ b/src/core/tables/__snapshots__/htmlTable.test.ts.snap
@@ -261,10 +261,14 @@ exports[`Html table render tests should match snapshot: Table with column variab
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: lukumäärä[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -431,10 +435,14 @@ exports[`Html table render tests should match snapshot: Table with missing data 
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: Eur / m2[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -462,10 +470,14 @@ exports[`Html table render tests should match snapshot: Table with only one cell
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: lukumäärä[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -1104,10 +1116,14 @@ exports[`Html table render tests should match snapshot: Table with row and colum
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -1746,7 +1762,9 @@ exports[`Html table render tests should match snapshot: Table with row and colum
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mTest footnote[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -2378,10 +2396,14 @@ exports[`Html table render tests should match snapshot: Table with row and colum
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -3548,10 +3570,14 @@ exports[`Html table render tests should match snapshot: Table with row variables
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: lukumäärä[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"
@@ -3579,13 +3605,19 @@ exports[`Html table render tests should match snapshot: Table with source and fo
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mYksikkö: lukumäärä[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mTest footnote[0m
   [36m</p>[39m
-  [36m<p>[39m
+  [36m<p[39m
+    [33mclass[39m=[32m"tableChart-metadata"[39m
+  [36m>[39m
     [0mLähde: PxVisualizer-fi[0m
   [36m</p>[39m
 [36m</div>[39m"

--- a/src/core/tables/__snapshots__/htmlTable.test.ts.snap
+++ b/src/core/tables/__snapshots__/htmlTable.test.ts.snap
@@ -261,16 +261,13 @@ exports[`Html table render tests should match snapshot: Table with column variab
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: lukumäärä[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -435,16 +432,13 @@ exports[`Html table render tests should match snapshot: Table with missing data 
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: Eur / m2[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -470,16 +464,13 @@ exports[`Html table render tests should match snapshot: Table with only one cell
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: lukumäärä[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -1116,16 +1107,13 @@ exports[`Html table render tests should match snapshot: Table with row and colum
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -1762,11 +1750,9 @@ exports[`Html table render tests should match snapshot: Table with row and colum
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mTest footnote[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -2396,16 +2382,13 @@ exports[`Html table render tests should match snapshot: Table with row and colum
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -3570,16 +3553,13 @@ exports[`Html table render tests should match snapshot: Table with row variables
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: lukumäärä[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;
 
@@ -3605,20 +3585,16 @@ exports[`Html table render tests should match snapshot: Table with source and fo
       [36m</tr>[39m
     [36m</tbody>[39m
   [36m</table>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m<span>[39m
     [0mYksikkö: lukumäärä[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mTest footnote[0m
-  [36m</p>[39m
-  [36m<p[39m
-    [33mclass[39m=[32m"tableChart-metadata"[39m
-  [36m>[39m
+  [36m</span>[39m
+  [36m<span>[39m
+    [36m<br />[39m
     [0mLähde: PxVisualizer-fi[0m
-  [36m</p>[39m
+  [36m</span>[39m
 [36m</div>[39m"
 `;

--- a/src/core/tables/htmlTable.ts
+++ b/src/core/tables/htmlTable.ts
@@ -33,42 +33,41 @@ export function renderHtmlTable(view: View, locale: string, options: IChartOptio
 
         container.append(table);
 
+        let isFirstMetadata: boolean = true;
+
+        // Helper function to add metadata elements
+        const addMetadata = (text: string) => {
+            const span = document.createElement('span');
+            if (!isFirstMetadata) span.append(document.createElement('br'));
+            span.append(text);
+            container.append(span);
+            isFirstMetadata = false;
+        };
+
         // Units
         if (options.showUnits) {
-            const pUnits = document.createElement('p');
-            pUnits.className = 'tableChart-metadata';
             const unitName = getFormattedUnits(view.units, locale);
             const units: string = `${Translations.unit[locale]}: ${unitName}`;
-            pUnits.append(units);
-            container.append(pUnits);
+            addMetadata(units);
         }
 
         // Footnote
         if (footnote) {
-            const pFootnote = document.createElement('p');
-            pFootnote.className = 'tableChart-metadata';
-            pFootnote.append(footnote);
-            container.append(pFootnote);
+            addMetadata(footnote);
         }
 
         // Last Updated
         if (options.showLastUpdated && view.lastUpdated) {
-            const pLastUpdated = document.createElement('p');
-            pLastUpdated.className = 'tableChart-metadata';
             const lastUpdatedText = getFormattedLastUpdatedText(view.lastUpdated, locale);
             if (lastUpdatedText) {
-                pLastUpdated.append(lastUpdatedText);
-                container.append(pLastUpdated);
+                addMetadata(lastUpdatedText);
             }
         }
 
         // Sources
         if (options.showSources) {
-            const pSources = document.createElement('p');
-            pSources.className = 'tableChart-metadata';
             const sources: string = `${Translations.source[locale]}: ${view.sources.map(source => source[locale]).join(', ')}`;
-            pSources.append(sources);
-            container.append(pSources);
+            addMetadata(sources);
         }
 
     } catch (error) {

--- a/src/core/tables/htmlTable.ts
+++ b/src/core/tables/htmlTable.ts
@@ -36,6 +36,7 @@ export function renderHtmlTable(view: View, locale: string, options: IChartOptio
         // Units
         if (options.showUnits) {
             const pUnits = document.createElement('p');
+            pUnits.className = 'tableChart-metadata';
             const unitName = getFormattedUnits(view.units, locale);
             const units: string = `${Translations.unit[locale]}: ${unitName}`;
             pUnits.append(units);
@@ -45,6 +46,7 @@ export function renderHtmlTable(view: View, locale: string, options: IChartOptio
         // Footnote
         if (footnote) {
             const pFootnote = document.createElement('p');
+            pFootnote.className = 'tableChart-metadata';
             pFootnote.append(footnote);
             container.append(pFootnote);
         }
@@ -52,6 +54,7 @@ export function renderHtmlTable(view: View, locale: string, options: IChartOptio
         // Last Updated
         if (options.showLastUpdated && view.lastUpdated) {
             const pLastUpdated = document.createElement('p');
+            pLastUpdated.className = 'tableChart-metadata';
             const lastUpdatedText = getFormattedLastUpdatedText(view.lastUpdated, locale);
             if (lastUpdatedText) {
                 pLastUpdated.append(lastUpdatedText);
@@ -62,6 +65,7 @@ export function renderHtmlTable(view: View, locale: string, options: IChartOptio
         // Sources
         if (options.showSources) {
             const pSources = document.createElement('p');
+            pSources.className = 'tableChart-metadata';
             const sources: string = `${Translations.source[locale]}: ${view.sources.map(source => source[locale]).join(', ')}`;
             pSources.append(sources);
             container.append(pSources);

--- a/src/react/components/chart/__snapshots__/chart.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/chart.test.tsx.snap
@@ -117,11 +117,9 @@ exports[`Rendering test renders chart data correctly 1`] = `
             </tr>
           </tbody>
         </table>
-        <p
-          class="tableChart-metadata"
-        >
+        <span>
           Lähde: PxVisualizer-fi
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -206,11 +204,9 @@ exports[`Rendering test renders chart data correctly with hidden context menu 1`
             </tr>
           </tbody>
         </table>
-        <p
-          class="tableChart-metadata"
-        >
+        <span>
           Lähde: PxVisualizer-fi
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -327,11 +323,9 @@ exports[`Rendering test renders chart data correctly with hidden title 1`] = `
             </tr>
           </tbody>
         </table>
-        <p
-          class="tableChart-metadata"
-        >
+        <span>
           Lähde: PxVisualizer-fi
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -448,11 +442,9 @@ exports[`Rendering test renders chart data correctly with hidden title and conte
             </tr>
           </tbody>
         </table>
-        <p
-          class="tableChart-metadata"
-        >
+        <span>
           Lähde: PxVisualizer-fi
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -530,11 +522,9 @@ exports[`Rendering test renders chart data correctly with hidden title and hidde
             </tr>
           </tbody>
         </table>
-        <p
-          class="tableChart-metadata"
-        >
+        <span>
           Lähde: PxVisualizer-fi
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -658,16 +648,13 @@ exports[`Rendering test renders chart data correctly with last updated date 1`] 
             </tr>
           </tbody>
         </table>
-        <p
-          class="tableChart-metadata"
-        >
+        <span>
           Päivitetty: 19.1.2023
-        </p>
-        <p
-          class="tableChart-metadata"
-        >
+        </span>
+        <span>
+          <br />
           Lähde: PxVisualizer-fi
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -1363,11 +1350,9 @@ exports[`Rendering test renders table data correctly 1`] = `
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -2050,16 +2035,13 @@ exports[`Rendering test renders table data correctly when given footnote 1`] = `
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Test footnote
-      </p>
-      <p
-        class="tableChart-metadata"
-      >
+      </span>
+      <span>
+        <br />
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -2742,11 +2724,9 @@ exports[`Rendering test renders table data correctly when sources are on 1`] = `
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -3429,11 +3409,9 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -4116,21 +4094,17 @@ exports[`Rendering test renders table data correctly when units and footnote are
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Yksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2
-      </p>
-      <p
-        class="tableChart-metadata"
-      >
+      </span>
+      <span>
+        <br />
         Test footnote
-      </p>
-      <p
-        class="tableChart-metadata"
-      >
+      </span>
+      <span>
+        <br />
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -4774,11 +4748,9 @@ exports[`Rendering test renders table data correctly with hidden context menu 1`
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -5454,11 +5426,9 @@ exports[`Rendering test renders table data correctly with hidden titles 1`] = `
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -6134,11 +6104,9 @@ exports[`Rendering test renders table data correctly with hidden titles and cont
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -6775,11 +6743,9 @@ exports[`Rendering test renders table data correctly with hidden titles and hidd
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -7462,16 +7428,13 @@ exports[`Rendering test renders table data correctly with last updated date 1`] 
           </tr>
         </tbody>
       </table>
-      <p
-        class="tableChart-metadata"
-      >
+      <span>
         Päivitetty: 19.1.2023
-      </p>
-      <p
-        class="tableChart-metadata"
-      >
+      </span>
+      <span>
+        <br />
         Lähde: PxVisualizer-fi
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>

--- a/src/react/components/chart/__snapshots__/chart.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/chart.test.tsx.snap
@@ -117,7 +117,9 @@ exports[`Rendering test renders chart data correctly 1`] = `
             </tr>
           </tbody>
         </table>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Lähde: PxVisualizer-fi
         </p>
       </div>
@@ -204,7 +206,9 @@ exports[`Rendering test renders chart data correctly with hidden context menu 1`
             </tr>
           </tbody>
         </table>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Lähde: PxVisualizer-fi
         </p>
       </div>
@@ -323,7 +327,9 @@ exports[`Rendering test renders chart data correctly with hidden title 1`] = `
             </tr>
           </tbody>
         </table>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Lähde: PxVisualizer-fi
         </p>
       </div>
@@ -442,7 +448,9 @@ exports[`Rendering test renders chart data correctly with hidden title and conte
             </tr>
           </tbody>
         </table>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Lähde: PxVisualizer-fi
         </p>
       </div>
@@ -522,7 +530,9 @@ exports[`Rendering test renders chart data correctly with hidden title and hidde
             </tr>
           </tbody>
         </table>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Lähde: PxVisualizer-fi
         </p>
       </div>
@@ -648,10 +658,14 @@ exports[`Rendering test renders chart data correctly with last updated date 1`] 
             </tr>
           </tbody>
         </table>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Päivitetty: 19.1.2023
         </p>
-        <p>
+        <p
+          class="tableChart-metadata"
+        >
           Lähde: PxVisualizer-fi
         </p>
       </div>
@@ -1349,7 +1363,9 @@ exports[`Rendering test renders table data correctly 1`] = `
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -2034,10 +2050,14 @@ exports[`Rendering test renders table data correctly when given footnote 1`] = `
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Test footnote
       </p>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -2722,7 +2742,9 @@ exports[`Rendering test renders table data correctly when sources are on 1`] = `
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -3407,7 +3429,9 @@ exports[`Rendering test renders table data correctly when titles are forced on 1
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -4092,13 +4116,19 @@ exports[`Rendering test renders table data correctly when units and footnote are
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Yksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2
       </p>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Test footnote
       </p>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -4744,7 +4774,9 @@ exports[`Rendering test renders table data correctly with hidden context menu 1`
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -5422,7 +5454,9 @@ exports[`Rendering test renders table data correctly with hidden titles 1`] = `
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -6100,7 +6134,9 @@ exports[`Rendering test renders table data correctly with hidden titles and cont
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -6739,7 +6775,9 @@ exports[`Rendering test renders table data correctly with hidden titles and hidd
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>
@@ -7424,10 +7462,14 @@ exports[`Rendering test renders table data correctly with last updated date 1`] 
           </tr>
         </tbody>
       </table>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Päivitetty: 19.1.2023
       </p>
-      <p>
+      <p
+        class="tableChart-metadata"
+      >
         Lähde: PxVisualizer-fi
       </p>
     </div>

--- a/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
@@ -635,10 +635,14 @@ exports[`TableView render tests Should render correctly 1`] = `
         </tr>
       </tbody>
     </table>
-    <p>
+    <p
+      class="tableChart-metadata"
+    >
       Yksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2
     </p>
-    <p>
+    <p
+      class="tableChart-metadata"
+    >
       Lähde: PxVisualizer-fi
     </p>
   </div>

--- a/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
+++ b/src/react/components/chart/__snapshots__/tableView.test.tsx.snap
@@ -635,16 +635,13 @@ exports[`TableView render tests Should render correctly 1`] = `
         </tr>
       </tbody>
     </table>
-    <p
-      class="tableChart-metadata"
-    >
+    <span>
       Yksikkö: Lukumäärä: lukumäärä, Neliövuokra (eur/m2): eur / m2
-    </p>
-    <p
-      class="tableChart-metadata"
-    >
+    </span>
+    <span>
+      <br />
       Lähde: PxVisualizer-fi
-    </p>
+    </span>
   </div>
 </DocumentFragment>
 `;

--- a/src/react/components/globalStyle/globalStyle.ts
+++ b/src/react/components/globalStyle/globalStyle.ts
@@ -73,4 +73,9 @@ export const GlobalStyle = createGlobalStyle`
         margin-bottom: 2rem;
         text-align: left;
     }
+
+    .tableChart-metadata {
+        margin-top: 0rem;
+        margin-bottom: 0rem;
+    }
 `;

--- a/src/react/components/globalStyle/globalStyle.ts
+++ b/src/react/components/globalStyle/globalStyle.ts
@@ -73,9 +73,4 @@ export const GlobalStyle = createGlobalStyle`
         margin-bottom: 2rem;
         text-align: left;
     }
-
-    .tableChart-metadata {
-        margin-top: 0rem;
-        margin-bottom: 0rem;
-    }
 `;


### PR DESCRIPTION
This fixes mismatching line spacing between charts and tables