### PR TITLE
[Fix] Stacked bar chart export colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/chartOptions/Utility/seriesDataBuilder.test.ts
+++ b/src/core/chartOptions/Utility/seriesDataBuilder.test.ts
@@ -101,6 +101,7 @@ describe('Highcharts series builder tests', () => {
                         width: 10,
                     }
                 },
+                colorIndex: 0,
                 data: [
                     {
                         custom: { "precision": 0, "preliminary": false },
@@ -131,6 +132,7 @@ describe('Highcharts series builder tests', () => {
                         width: 10,
                     },
                 },
+                colorIndex: 1,
                 data: [
                     {
                         custom: { "precision": 0, "preliminary": false },
@@ -168,6 +170,7 @@ describe('Highcharts series builder tests', () => {
                         width: 10,
                     },
                 },
+                colorIndex: 0,
                 data: [
                     {
                         custom: { "precision": 1, "preliminary": false },
@@ -203,6 +206,7 @@ describe('Highcharts series builder tests', () => {
         const expectedSeries = [
             {
                 animation: false,
+                colorIndex: 0,
                 data: [
                     {
                         custom: { "precision": 0, "preliminary": false },
@@ -221,6 +225,7 @@ describe('Highcharts series builder tests', () => {
             },
             {
                 animation: false,
+                colorIndex: 1,
                 data: [
                     {
                         custom: { "precision": 0, "preliminary": false },
@@ -246,6 +251,7 @@ describe('Highcharts series builder tests', () => {
         const expectedSeries = [
             {
                 animation: false,
+                colorIndex: 0,
                 data: [
                     {
                         custom: { "precision": 1, "preliminary": false },
@@ -275,5 +281,43 @@ describe('Highcharts series builder tests', () => {
         ];
 
         expect(buildColumnChartSeries(simpleQuarterVerticalBarchartViewFixture, 'fi')).toEqual(expectedSeries);
+    });
+
+    it('Should keep color assignment stable when horizontal bar series order is reversed', () => {
+        const reversedSeries = buildBarChartSeries(simpleGroupHorizontalBarchartViewFixture, 'fi', true);
+
+        expect(reversedSeries).toMatchObject([
+            {
+                colorIndex: 0,
+                index: 1,
+                name: '2015Q1',
+                type: 'bar'
+            },
+            {
+                colorIndex: 1,
+                index: 0,
+                name: '2015Q2',
+                type: 'bar'
+            }
+        ]);
+    });
+
+    it('Should keep color assignment stable when column series order is reversed', () => {
+        const reversedSeries = buildColumnChartSeries(simpleGroupHorizontalBarchartViewFixture, 'fi', true);
+
+        expect(reversedSeries).toMatchObject([
+            {
+                colorIndex: 0,
+                index: 1,
+                name: '2015Q1',
+                type: 'column'
+            },
+            {
+                colorIndex: 1,
+                index: 0,
+                name: '2015Q2',
+                type: 'column'
+            }
+        ]);
     });
 });

--- a/src/core/chartOptions/Utility/seriesDataBuilder.ts
+++ b/src/core/chartOptions/Utility/seriesDataBuilder.ts
@@ -13,6 +13,7 @@ export const buildBarChartSeries = (view: View, locale: string, reverseOrder: bo
     view.series.map((s, sIndex) => ({
         ...commonSeriesOptions(s, view, locale),
         ...(patternFill && buildPatternObject(sIndex)),
+        colorIndex: sIndex,
         index: reverseOrder ? view.series.length - 1 - sIndex : sIndex,
         type: 'bar',
     }));
@@ -21,6 +22,7 @@ export const buildColumnChartSeries = (view: View, locale: string, reverseOrder:
     view.series.map((s, sIndex) => ({
         ...commonSeriesOptions(s, view, locale),
         ...(patternFill && buildPatternObject(sIndex)),
+        colorIndex: sIndex,
         index: reverseOrder ? view.series.length - 1 - sIndex : sIndex,
         type: 'column'
     }));


### PR DESCRIPTION
Fixes the bug where png/svg exports of stacked bar/column charts had inverted color indeces by assigning specific colorIndex in bar/column chart series building. Changes covered by two new tests.