### PR TITLE
[Accessibility] Forces chart aria label to read only the title of the chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsfinland/pxvisualizer",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Component library for visualizing PxGraf data",
   "main": "./dist/pxv.cjs",
   "jestSonar": {

--- a/src/core/chartOptions/chartOptions.ts
+++ b/src/core/chartOptions/chartOptions.ts
@@ -40,7 +40,7 @@ export const commonChartOptions = (view: View, locale: string, options?: IChartO
         yAxis: [commonYAxisOptions],
         lang: {
             accessibility: {
-                chartContainerLabel: "{title}" // Reads the title of the chart but omits the 'Highcharts interactive chart' part which is read by default and is redundant in our case
+                chartContainerLabel: view.header[locale] // Reads the title of the chart but omits the 'Highcharts interactive chart' part which is read by default and is redundant in our case
             }
         }
     };

--- a/src/core/chartOptions/chartOptions.ts
+++ b/src/core/chartOptions/chartOptions.ts
@@ -37,7 +37,12 @@ export const commonChartOptions = (view: View, locale: string, options?: IChartO
         tooltip: {
             formatter: getToolTipFormatterFunction(view, locale)
         },
-        yAxis: [commonYAxisOptions]
+        yAxis: [commonYAxisOptions],
+        lang: {
+            accessibility: {
+                chartContainerLabel: "{title}" // Reads the title of the chart but omits the 'Highcharts interactive chart' part which is read by default and is redundant in our case
+            }
+        }
     };
 }
 


### PR DESCRIPTION
Fixes the "Highcharts interactive chart" aria label issue